### PR TITLE
Use TextEditorOptions and upgrade tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,4 +1,3 @@
-// A launch configuration that compiles the extension and then opens it inside a new window
 {
 	"version": "0.2.0",
 	"configurations": [

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -7,7 +7,8 @@ import {
 	workspace,
 	Disposable,
 	TextDocument,
-	TextEditor
+	TextEditor,
+	TextEditorOptions
 } from 'vscode';
 import * as Utils from './Utils';
 import {
@@ -19,9 +20,6 @@ import {
 import {
 	EditorConfigProvider
 } from './interfaces/editorConfigProvider';
-import {
-	EditorSettings
-} from './interfaces/editorSettings';
 
 /**
  * Listens to vscode document open and maintains a map
@@ -31,7 +29,7 @@ class DocumentWatcher implements EditorConfigProvider {
 
 	private _documentToConfigMap: { [uri: string]: editorconfig.knownProps };
 	private _disposable: Disposable;
-	private _defaults: EditorSettings;
+	private _defaults: TextEditorOptions;
 
 	constructor() {
 		const subscriptions: Disposable[] = [];

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -2,12 +2,10 @@
 
 import * as editorconfig from 'editorconfig';
 import {
-	EditorSettings
-} from './interfaces/editorSettings';
-import {
 	window,
 	TextDocument,
-	TextEditor
+	TextEditor,
+	TextEditorOptions
 } from 'vscode';
 
 /**
@@ -15,8 +13,8 @@ import {
  */
 export function fromEditorConfig(
 	config: editorconfig.knownProps,
-	defaults: EditorSettings
-): EditorSettings {
+	defaults: TextEditorOptions
+): TextEditorOptions {
 	return {
 		insertSpaces: config.indent_style
 			? config.indent_style !== 'tab'
@@ -30,7 +28,7 @@ export function fromEditorConfig(
 /**
  * Convert vscode editor options to .editorconfig values
  */
-export function toEditorConfig(options: EditorSettings) {
+export function toEditorConfig(options: TextEditorOptions) {
 	const result: editorconfig.knownProps = {};
 
 	switch (options.insertSpaces) {

--- a/src/interfaces/editorSettings.ts
+++ b/src/interfaces/editorSettings.ts
@@ -1,8 +1,0 @@
-'use strict';
-
-// TODO: remove when https://github.com/Microsoft/vscode/issues/2797
-// is resolved
-export interface EditorSettings {
-	tabSize: string | number;
-	insertSpaces: string | boolean;
-}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,5 +58,4 @@ suite('EditorConfig extension', () => {
 			);
 		}
 	});
-
 });


### PR DESCRIPTION
- Removed `editorSettings` and used `TextEditorOptions`
- Upgrade the tests to use the latest `vscode` version