### PR TITLE
ignore transormation if no .editorconfig was found

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -105,6 +105,10 @@ class DocumentWatcher implements EditorConfigProvider {
 
 		return editorconfig.parse(path)
 			.then((config: editorconfig.knownProps) => {
+				if (Object.keys(config).length === 0) {
+					return;
+				}
+
 				if (config.indent_size === 'tab') {
 					config.indent_size = config.tab_width;
 				}


### PR DESCRIPTION
This PR fixes #33. That issue was reopened because there was a specific edge case with the global `settings.json` file. It showed the warning that the settings file was overriding the editorconfig `trim_trailing_whitespace` setting although no `.editorconfig` file is associated with the global `settings.json` file. The reason for this is that `editorconfig.parse()` returns an empty object if no `.editorconfig` is associated with the requested file (see https://github.com/editorconfig/editorconfig-core-js/issues/36) and [this](https://github.com/editorconfig/editorconfig-vscode/blob/master/src/transformations/trimTrailingWhitespace.ts#L26) line was evaluating to true because `editorconfig.trim_trailing_whitespace` is `undefined`.

@jedmao If you think there are better options to solve this, feel free to provide feedback :). This seemed the most elegant solution.