### PR TITLE
Don't display trim trailing whitespace warning when no setting is set

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,37 +1,16 @@
 # EditorConfig is awesome: http://EditorConfig.org
 
-# top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
+trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.ts]
 indent_style = tab
 indent_size = 4
 
-# Matches multiple files with brace expansion notation
-# Set default charset
-[*.{js,py}]
-charset = utf-8
-
-# 4 space indentation
-[*.py]
-indent_style = space
-indent_size = 4
-
-# Tab indentation (no size specified)
-[Makefile]
-indent_style = tab
-
-# Indentation override for all JS under lib directory
-[lib/**.js]
-indent_style = space
-indent_size = 2
-
-# Matches the exact files either package.json or .travis.yml
 [{package.json,.travis.yml}]
 indent_style = space
 indent_size = 2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^0.10.10"
@@ -41,9 +41,9 @@
     "editorconfig": "0.12.2"
   },
   "devDependencies": {
-    "tslint": "^3.3.0",
+    "tslint": "^3.7.1",
     "typescript": "^1.8.9",
-    "vscode": "^0.11.6",
+    "vscode": "^0.11.10",
     "vscode-test-utils": "0.0.6"
   },
   "scripts": {

--- a/src/transformations/trimTrailingWhitespace.ts
+++ b/src/transformations/trimTrailingWhitespace.ts
@@ -23,15 +23,17 @@ export function transform(
 		.getConfiguration('files')
 		.get('trimTrailingWhitespace', false);
 
-	if (editorTrimsWhitespace && !editorconfig.trim_trailing_whitespace) {
-		window.showWarningMessage([
-			'The trimTrailingWhitespace workspace or user setting is',
-			'overriding the EditorConfig setting for this file.'
-		].join(' '));
+	if (editorTrimsWhitespace) {
+		if (editorconfig.trim_trailing_whitespace === false) {
+			window.showWarningMessage([
+				'The trimTrailingWhitespace workspace or user setting is',
+				'overriding the EditorConfig setting for this file.'
+			].join(' '));
+		}
 		return Promise.resolve([true]);
 	}
 
-	if (editorTrimsWhitespace || !editorconfig.trim_trailing_whitespace) {
+	if (!editorconfig.trim_trailing_whitespace) {
 		return Promise.resolve([true]);
 	}
 


### PR DESCRIPTION
Fixes #33 by simply looking for an explicit `false` value setting in the `.editorconfig` for the file in question. Previously, no setting at all was displaying the warning, but that doesn't exactly make sense.

Grr – I'm having a hard time explaining the edge case here.