### PR TITLE
v0.3.0: Support end_of_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0
+- [Support `end_of_line`](https://github.com/editorconfig/editorconfig-vscode/issues/26) (thanks [`@jedmao`](https://github.com/jedmao))!
+
 ## 0.2.3
 - [Fix applying transformations to .editorconfig itself](https://github.com/editorconfig/editorconfig-vscode/issues/9) (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!
 - [Fix marketplace icon](https://github.com/editorconfig/editorconfig-vscode/commits/master) (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ ext install EditorConfig
 * `indent_style`
 * `indent_size`
 * `tab_width`
+* `end_of_line`
 * `insert_final_newline`
 * `trim_trailing_whitespace`
 
 ## On the backlog
 
 * `charset`
-* `end_of_line`
 
 [Visual Studio Code]: https://code.visualstudio.com/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.0.0"


### PR DESCRIPTION
## 0.3.0
- [Support `end_of_line`](https://github.com/editorconfig/editorconfig-vscode/issues/26)
