### PR TITLE
Unlink old changelog entries giving a 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@
 - [Trim trailing whitespace before inserting final newline](https://github.com/editorconfig/editorconfig-vscode/issues/2) (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!
 
 ## 0.2.0
-- [Support `trim_trailing_whitespace`](https://github.com/Microsoft/vscode-editorconfig/issues/6) (thanks [`@torarvid`](https://github.com/torarvid))!
-- Fix [text editor defaults](https://github.com/Microsoft/vscode-editorconfig/issues/19) (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!
-- Fix [multiple execution times](https://github.com/Microsoft/vscode-editorconfig/issues/21) (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!
+- Support `trim_trailing_whitespace` (thanks [`@torarvid`](https://github.com/torarvid))!
+- Fix text editor defaults (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!
+- Fix multiple execution times (thanks [`@SamVerschueren`](https://github.com/SamVerschueren))!
 
 ## 0.1.0
 - Forked from [`Microsoft/vscode-editorconfig`](https://github.com/Microsoft/vscode-editorconfig).


### PR DESCRIPTION
Old entries pointing tot the `Microsoft/vscode-editorconfig` repo in the Changelog result in a 404 as that repo no longer has an issues section.

This change unlinks those entries.