### PR TITLE
take detectIndentation into account - fixes #52

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -119,11 +119,12 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	private _onConfigChanged() {
-		this._defaults = {
-			tabSize: workspace.getConfiguration('editor')
-				.get<string | number>('tabSize'),
-			insertSpaces: workspace.getConfiguration('editor')
-				.get<string | boolean>('insertSpaces')
+		const workspaceConfig = workspace.getConfiguration('editor');
+		const detectIndentation = workspaceConfig.get<boolean>('detectIndentation');
+
+		this._defaults = (detectIndentation) ? {} : {
+			tabSize: workspaceConfig.get<string | number>('tabSize'),
+			insertSpaces: workspaceConfig.get<string | boolean>('insertSpaces')
 		};
 	}
 }

--- a/test/fixtures/detect-indentation/.editorconfig
+++ b/test/fixtures/detect-indentation/.editorconfig
@@ -1,0 +1,1 @@
+root = true

--- a/test/fixtures/detect-indentation/indent-size-2
+++ b/test/fixtures/detect-indentation/indent-size-2
@@ -1,0 +1,4 @@
+foo
+  bar
+    baz
+  qux

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -165,6 +165,26 @@ suite('EditorConfig extension', () => {
 		}, 25);
 	});
 
+	test('detect indentation', async (done) => {
+		const options = await getOptionsForFixture([
+			'detect-indentation',
+			'indent-size-2'
+		]);
+
+		assert.strictEqual(
+			options.tabSize,
+			undefined,
+			'editor has no tabSize defined'
+		);
+
+		assert.strictEqual(
+			options.insertSpaces,
+			undefined,
+			'editor has no insertSpaces defined'
+		);
+
+		done();
+	});
 });
 
 function withSetting(


### PR DESCRIPTION
This PR fixes #52. 

The thing is that if `detectIndentation` is set to `true`, we shouldn't provide default values for `tabSize` and `insertSpaces` as they are being automatically detected.

As explained in that issue, if `editorconfig.parse` would've returned `undefined` if no `.editorconfig` file could be found, we could exit early and non of these would happen.