### PR TITLE
add EditorConfig link - fixes #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EditorConfig for [Visual Studio Code][]
+# [EditorConfig][] for [Visual Studio Code][]
 [![Travis Build Status][travis-img]][travis] [![Gitter][chat-img]][chat]
 
 [travis]: https://travis-ci.org/editorconfig/editorconfig-vscode
@@ -30,3 +30,4 @@ ext install EditorConfig
 * `charset`
 
 [Visual Studio Code]: https://code.visualstudio.com/
+[EditorConfig]: http://editorconfig.org/


### PR DESCRIPTION
Just a quick fix for #65. Doesn't need a new release but just made sure `EditorConfig` is clickable in the marketplace https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig.

@jedmao It's just a suggestion, if you want to solve that issue differently, feel free :).