### PR TITLE
Adding support to auto complete property names and values

### DIFF
--- a/src/EditorConfigCompletionProvider.ts
+++ b/src/EditorConfigCompletionProvider.ts
@@ -4,14 +4,14 @@ import { TextDocument, Range, Position } from 'vscode'
 class EditorConfigCompletionProvider implements CompletionItemProvider {
 
 	private readonly properties: Property[] = [
-		new Property("root", ["true", "false"]),
-		new Property("charset", ["utf-8", "utf-8-bom", "utf-16be", "utf-16le", "latin1"]),
-		new Property("end_of_line", ["lf", "cr", "crlf"]),
-		new Property("indent_style", ["tab", "space"]),
-		new Property("indent_size", ["1", "2", "3", "4", "5", "6", "7", "8"]),
-		new Property("insert_final_newline", ["true", "false"]),
-		new Property("tab_width", ["1", "2", "3", "4", "5", "6", "7", "8"]),
-		new Property("trim_trailing_whitespace", ["true", "false"])
+		new Property("root", ["true", "false"], "Special property that should be specified at the top of the file outside of any sections. Set to true to stop .editorconfig files search on current file."),
+		new Property("charset", ["utf-8", "utf-8-bom", "utf-16be", "utf-16le", "latin1"], "Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the character set. Use of utf-8-bom is discouraged."),
+		new Property("end_of_line", ["lf", "cr", "crlf"], "Set to lf, cr, or crlf to control how line breaks are represented."),
+		new Property("indent_style", ["tab", "space"], "Set to tab or space to use hard tabs or soft tabs respectively."),
+		new Property("indent_size", ["1", "2", "3", "4", "5", "6", "7", "8"], " A whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used."),
+		new Property("insert_final_newline", ["true", "false"], "Set to true to ensure file ends with a newline when saving and false to ensure it doesn't."),
+		new Property("tab_width", ["1", "2", "3", "4", "5", "6", "7", "8"], "A whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn't usually need to be specified."),
+		new Property("trim_trailing_whitespace", ["true", "false"], "Set to true to remove any whitespace characters preceding newline characters and false to ensure it doesn't.")
 	];
 
 	// =========================================================================
@@ -30,6 +30,10 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 		} else {
 			return this.autoCompletePropertyNames();
 		}
+	}
+
+	public resolveCompletionItem(item: CompletionItem, token: CancellationToken): CompletionItem {
+		return item;
 	}
 
 	// =========================================================================
@@ -77,7 +81,11 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// CONVERTERS
 	// =========================================================================
 	private convertPropertyNamesToCompletionItems(properties: Property[]): CompletionItem[] {
-		return properties.map(property => new CompletionItem(property.name, CompletionItemKind.Property));
+		return properties.map(property => {
+			let completionItem = new CompletionItem(property.name, CompletionItemKind.Property);
+			completionItem.documentation = property.description;
+			return completionItem;
+		});
 	}
 
 	private convertPropertyValuesToCompletionItems(values: string[]): CompletionItem[] {
@@ -88,10 +96,12 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 class Property {
 	name: string;
 	values: string[];
+	description: string;
 
-	constructor(name: string, values: string[]) {
+	constructor(name: string, values: string[], description: string) {
 		this.name = name;
 		this.values = values;
+		this.description = description;
 	}
 }
 

--- a/src/EditorConfigCompletionProvider.ts
+++ b/src/EditorConfigCompletionProvider.ts
@@ -19,11 +19,11 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// =========================================================================
 	public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): CompletionItem[] {
 		// get text where code completion was activated
-		let rangeFromLineStart = new Range(new Position(position.line, 0), position);
-		let lineText = document.getText(rangeFromLineStart);
+		const rangeFromLineStart = new Range(new Position(position.line, 0), position);
+		const lineText = document.getText(rangeFromLineStart);
 
 		// check if checking for property names or values
-		let lineTextHasPropertyName = lineText.indexOf('=') >= 0;
+		const lineTextHasPropertyName = lineText.indexOf('=') >= 0;
 
 		if (lineTextHasPropertyName) {
 			return this.autoCompletePropertyValues(lineText);
@@ -40,8 +40,8 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// AUTO COMPLETE
 	// =========================================================================
 	private autoCompletePropertyValues(lineText: string): CompletionItem[] {
-		let propertyName = this.extractPropertyName(lineText);
-		let propertyValues = this.filterPropertyValues(propertyName);
+		const propertyName = this.extractPropertyName(lineText);
+		const propertyValues = this.filterPropertyValues(propertyName);
 		return this.convertPropertyValuesToCompletionItems(propertyValues);
 	}
 
@@ -53,11 +53,11 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// PARSER
 	// =========================================================================
 	private extractPropertyName(lineText: string): string {
-		let lineTextParts = lineText.split('=');
+		const lineTextParts = lineText.split('=');
 		if (lineTextParts.length == 0) {
 			return '';
 		}
-		let propertyName = lineTextParts[0].trim().toLowerCase();
+		const propertyName = lineTextParts[0].trim().toLowerCase();
 		return propertyName;
 	}
 
@@ -66,7 +66,7 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// =========================================================================
 	private filterPropertyValues(propertyName: string): string[] {
 		// filter
-		let matchingProperty = this.properties.find(property => property.name == propertyName);
+		const matchingProperty = this.properties.find(property => property.name == propertyName);
 
 		// if not found anything, there are no values to display
 		if (matchingProperty == undefined) {
@@ -82,7 +82,7 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// =========================================================================
 	private convertPropertyNamesToCompletionItems(properties: Property[]): CompletionItem[] {
 		return properties.map(property => {
-			let completionItem = new CompletionItem(property.name, CompletionItemKind.Property);
+			const completionItem = new CompletionItem(property.name, CompletionItemKind.Property);
 			completionItem.documentation = property.description;
 			return completionItem;
 		});

--- a/src/EditorConfigCompletionProvider.ts
+++ b/src/EditorConfigCompletionProvider.ts
@@ -4,14 +4,14 @@ import { TextDocument, Range, Position } from 'vscode'
 class EditorConfigCompletionProvider implements CompletionItemProvider {
 
 	private readonly properties: Property[] = [
-		new Property('root', ['true', 'false'], 'Special property that should be specified at the top of the file outside of any sections. Set to true to stop .editorconfig files search on current file.'),
-		new Property('charset', ['utf-8', 'utf-8-bom', 'utf-16be', 'utf-16le', 'latin1'], 'Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the character set. Use of utf-8-bom is discouraged.'),
-		new Property('end_of_line', ['lf', 'cr', 'crlf'], 'Set to lf, cr, or crlf to control how line breaks are represented.'),
-		new Property('indent_style', ['tab', 'space'], 'Set to tab or space to use hard tabs or soft tabs respectively.'),
-		new Property('indent_size', ['1', '2', '3', '4', '5', '6', '7', '8'], ' A whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used.'),
-		new Property('insert_final_newline', ['true', 'false'], 'Set to true to ensure file ends with a newline when saving and false to ensure it doesn\'t.'),
-		new Property('tab_width', ['1', '2', '3', '4', '5', '6', '7', '8'], 'A whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn\'t usually need to be specified.'),
-		new Property('trim_trailing_whitespace', ['true', 'false'], 'Set to true to remove any whitespace characters preceding newline characters and false to ensure it doesn\'t.')
+		new Property('root', ['true', 'false', 'unset'], 'Special property that should be specified at the top of the file outside of any sections. Set to true to stop .editorconfig files search on current file.'),
+		new Property('charset', ['utf-8', 'utf-8-bom', 'utf-16be', 'utf-16le', 'latin1', 'unset'], 'Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the character set. Use of utf-8-bom is discouraged.'),
+		new Property('end_of_line', ['lf', 'cr', 'crlf', 'unset'], 'Set to lf, cr, or crlf to control how line breaks are represented.'),
+		new Property('indent_style', ['tab', 'space', 'unset'], 'Set to tab or space to use hard tabs or soft tabs respectively.'),
+		new Property('indent_size', ['1', '2', '3', '4', '5', '6', '7', '8', 'unset'], ' A whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used.'),
+		new Property('insert_final_newline', ['true', 'false', 'unset'], 'Set to true to ensure file ends with a newline when saving and false to ensure it doesn\'t.'),
+		new Property('tab_width', ['1', '2', '3', '4', '5', '6', '7', '8', 'unset'], 'A whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn\'t usually need to be specified.'),
+		new Property('trim_trailing_whitespace', ['true', 'false', 'unset'], 'Set to true to remove any whitespace characters preceding newline characters and false to ensure it doesn\'t.')
 	];
 
 	// =========================================================================

--- a/src/EditorConfigCompletionProvider.ts
+++ b/src/EditorConfigCompletionProvider.ts
@@ -1,0 +1,80 @@
+import { CompletionItemProvider, CompletionItem, CompletionItemKind, CancellationToken } from 'vscode'
+import { TextDocument, Range, Position } from 'vscode'
+
+class EditorConfigCompletionProvider implements CompletionItemProvider {
+
+	private properties: Property[] = [
+		new Property("root", ["true", "false"]),
+		new Property("charset", ["utf-8", "utf-8-bom", "utf-16be", "utf-16le", "latin1"]),
+		new Property("end_of_line", ["lf", "cr", "crlf"]),
+		new Property("indent_style", ["tab", "space"]),
+		new Property("indent_size", ["1", "2", "3", "4", "5", "6", "7", "8"]),
+		new Property("insert_final_newline", ["true", "false"]),
+		new Property("tab_width", ["1", "2", "3", "4", "5", "6", "7", "8"]),
+		new Property("trim_trailing_whitespace", ["true", "false"])
+	];
+
+	// =========================================================================
+	// PUBLIC INTERFACE
+	public provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): CompletionItem[] {
+		// get text where code completion was activated
+		let rangeFromLineStart = new Range(new Position(position.line, 0), position);
+		let lineText = document.getText(rangeFromLineStart);
+
+		// check if checking for property names or values
+		if (lineText.indexOf("=") >= 0) {
+			let propertyName = this.extractPropertyName(lineText);
+			let propertyValues = this.filterPropertyValues(propertyName);
+			return this.convertPropertyValuesToCompletionItems(propertyValues);
+		} else {
+			return this.convertPropertyNamesToCompletionItems(this.properties);
+		}
+	}
+
+	// =========================================================================
+	// PARSING
+	private extractPropertyName(lineText: string): string {
+		let lineTextParts = lineText.split("=");
+		if (lineTextParts.length == 0) {
+			return "";
+		}
+		let propertyName = lineTextParts[0].trim().toLowerCase();
+		return propertyName;
+	}
+
+	// =========================================================================
+	// FILTERING
+	private filterPropertyValues(propertyName: string): string[] {
+		// filter
+		let matchingProperty = this.properties.find(property => property.name == propertyName);
+
+		// if not found anything, there are no values to display
+		if (matchingProperty == undefined) {
+			return [];
+		}
+
+		// return values of the property
+		return matchingProperty.values;
+	}
+
+	// =========================================================================
+	// CONVERTERS
+	private convertPropertyNamesToCompletionItems(properties: Property[]): CompletionItem[] {
+		return properties.map(property => new CompletionItem(property.name, CompletionItemKind.Property));
+	}
+
+	private convertPropertyValuesToCompletionItems(values: string[]): CompletionItem[] {
+		return values.map(value => new CompletionItem(value, CompletionItemKind.Value));
+	}
+}
+class Property {
+	name: string;
+	values: string[];
+
+	constructor(name: string, values: string[]) {
+		this.name = name;
+		this.values = values;
+	}
+}
+
+export default EditorConfigCompletionProvider;

--- a/src/EditorConfigCompletionProvider.ts
+++ b/src/EditorConfigCompletionProvider.ts
@@ -4,14 +4,14 @@ import { TextDocument, Range, Position } from 'vscode'
 class EditorConfigCompletionProvider implements CompletionItemProvider {
 
 	private readonly properties: Property[] = [
-		new Property("root", ["true", "false"], "Special property that should be specified at the top of the file outside of any sections. Set to true to stop .editorconfig files search on current file."),
-		new Property("charset", ["utf-8", "utf-8-bom", "utf-16be", "utf-16le", "latin1"], "Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the character set. Use of utf-8-bom is discouraged."),
-		new Property("end_of_line", ["lf", "cr", "crlf"], "Set to lf, cr, or crlf to control how line breaks are represented."),
-		new Property("indent_style", ["tab", "space"], "Set to tab or space to use hard tabs or soft tabs respectively."),
-		new Property("indent_size", ["1", "2", "3", "4", "5", "6", "7", "8"], " A whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used."),
-		new Property("insert_final_newline", ["true", "false"], "Set to true to ensure file ends with a newline when saving and false to ensure it doesn't."),
-		new Property("tab_width", ["1", "2", "3", "4", "5", "6", "7", "8"], "A whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn't usually need to be specified."),
-		new Property("trim_trailing_whitespace", ["true", "false"], "Set to true to remove any whitespace characters preceding newline characters and false to ensure it doesn't.")
+		new Property('root', ['true', 'false'], 'Special property that should be specified at the top of the file outside of any sections. Set to true to stop .editorconfig files search on current file.'),
+		new Property('charset', ['utf-8', 'utf-8-bom', 'utf-16be', 'utf-16le', 'latin1'], 'Set to latin1, utf-8, utf-8-bom, utf-16be or utf-16le to control the character set. Use of utf-8-bom is discouraged.'),
+		new Property('end_of_line', ['lf', 'cr', 'crlf'], 'Set to lf, cr, or crlf to control how line breaks are represented.'),
+		new Property('indent_style', ['tab', 'space'], 'Set to tab or space to use hard tabs or soft tabs respectively.'),
+		new Property('indent_size', ['1', '2', '3', '4', '5', '6', '7', '8'], ' A whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used.'),
+		new Property('insert_final_newline', ['true', 'false'], 'Set to true to ensure file ends with a newline when saving and false to ensure it doesn\'t.'),
+		new Property('tab_width', ['1', '2', '3', '4', '5', '6', '7', '8'], 'A whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn\'t usually need to be specified.'),
+		new Property('trim_trailing_whitespace', ['true', 'false'], 'Set to true to remove any whitespace characters preceding newline characters and false to ensure it doesn\'t.')
 	];
 
 	// =========================================================================
@@ -23,7 +23,7 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 		let lineText = document.getText(rangeFromLineStart);
 
 		// check if checking for property names or values
-		let lineTextHasPropertyName = lineText.indexOf("=") >= 0;
+		let lineTextHasPropertyName = lineText.indexOf('=') >= 0;
 
 		if (lineTextHasPropertyName) {
 			return this.autoCompletePropertyValues(lineText);
@@ -53,9 +53,9 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 	// PARSER
 	// =========================================================================
 	private extractPropertyName(lineText: string): string {
-		let lineTextParts = lineText.split("=");
+		let lineTextParts = lineText.split('=');
 		if (lineTextParts.length == 0) {
-			return "";
+			return '';
 		}
 		let propertyName = lineTextParts[0].trim().toLowerCase();
 		return propertyName;

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -12,7 +12,7 @@ export function activate(ctx: ExtensionContext): void {
 	ctx.subscriptions.push(new DocumentWatcher());
 
 	// register .editorconfig file completion provider
-	let editorConfigFileSelector: DocumentSelector = ['properties', { pattern: '.editorconfig' }];
+	let editorConfigFileSelector: DocumentSelector = { language: 'properties', pattern: '**/.editorconfig' };
 	languages.registerCompletionItemProvider(editorConfigFileSelector, new EditorConfigCompletionProvider());
 
 	// register a command handler to generate a .editorconfig file

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -12,7 +12,7 @@ export function activate(ctx: ExtensionContext): void {
 	ctx.subscriptions.push(new DocumentWatcher());
 
 	// register .editorconfig file completion provider
-	let editorConfigFileSelector: DocumentSelector = ["properties", { pattern: '.editorconfig' }];
+	let editorConfigFileSelector: DocumentSelector = ['properties', { pattern: '.editorconfig' }];
 	languages.registerCompletionItemProvider(editorConfigFileSelector, new EditorConfigCompletionProvider());
 
 	// register a command handler to generate a .editorconfig file

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -1,20 +1,19 @@
 'use strict';
 
-import {
-	ExtensionContext,
-	commands
-} from 'vscode';
-
+import { ExtensionContext, DocumentSelector, commands, languages } from 'vscode';
+import EditorConfigCompletionProvider from './EditorConfigCompletionProvider';
 import DocumentWatcher from './DocumentWatcher';
-import {
-	generateEditorConfig
-} from './commands/generateEditorConfig';
+import { generateEditorConfig } from './commands/generateEditorConfig';
 
 /**
  * Main entry
  */
 export function activate(ctx: ExtensionContext): void {
 	ctx.subscriptions.push(new DocumentWatcher());
+
+	// register .editorconfig file completion provider
+	let editorConfigFileSelector: DocumentSelector = ["properties", { pattern: '.editorconfig' }];
+	languages.registerCompletionItemProvider(editorConfigFileSelector, new EditorConfigCompletionProvider());
 
 	// register a command handler to generate a .editorconfig file
 	commands.registerCommand(

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -12,7 +12,7 @@ export function activate(ctx: ExtensionContext): void {
 	ctx.subscriptions.push(new DocumentWatcher());
 
 	// register .editorconfig file completion provider
-	let editorConfigFileSelector: DocumentSelector = { language: 'properties', pattern: '**/.editorconfig' };
+	const editorConfigFileSelector: DocumentSelector = { language: 'properties', pattern: '**/.editorconfig' };
 	languages.registerCompletionItemProvider(editorConfigFileSelector, new EditorConfigCompletionProvider());
 
 	// register a command handler to generate a .editorconfig file


### PR DESCRIPTION
Fixes #41 

This PR adds supports to autocomplete property names and values when working in the `.editorconfig` file.