### PR TITLE
Update .vscodeignore to exclude unnecessary files and folders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules
 .DS_Store
 Thumbs.db
 *.log
-
+.vscode-test
 test/fixtures/end_of_line/*/test
 test/fixtures/insert_final_newline/*/test
 test/fixtures/trim_trailing_whitespace/*/test

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,9 @@
 .vscode/**
+.vscode-test/**
 typings/**
 out/test/**
 test/**
 src/**
-vscode-test/**
 **/*.map
 .editorconfig
 .gitignore

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,7 +3,11 @@ typings/**
 out/test/**
 test/**
 src/**
+vscode-test/**
 **/*.map
+.editorconfig
 .gitignore
+.travis.yml
 tsconfig.json
+tslint.json
 vsc-extension-quickstart.md

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -170,13 +170,13 @@ suite('EditorConfig extension', () => {
 
 		assert.strictEqual(
 			options.tabSize,
-			undefined,
+			2,
 			'editor has no tabSize defined'
 		);
 
 		assert.strictEqual(
 			options.insertSpaces,
-			undefined,
+			true,
 			'editor has no insertSpaces defined'
 		);
 


### PR DESCRIPTION
This PR makes the distribution package smaller, and quicker to download, as it excluds the `.vscode-test` folder amongst others, which is redundant.