### PR TITLE
Fix tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "scripts": {
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "compile": "tsc -p ./",
-    "lint": "tslint 'src/**/*.ts' 'test/**/*.ts'",
+    "compile": "tsc",
+    "lint": "tslint --project tsconfig.json",
     "pretest": "npm run lint && npm run compile",
     "test": "node ./node_modules/vscode/bin/test",
     "vscode:prepublish": "npm run compile"

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "vscode-test-utils": "^0.0.8"
   },
   "scripts": {
-    "precompile": "node ./node_modules/vscode/bin/install",
-    "compile": "tsc",
-    "lint": "tslint --project tsconfig.json",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "compile": "tsc -p ./",
+    "lint": "tslint 'src/**/*.ts' 'test/**/*.ts'",
     "pretest": "npm run lint && npm run compile",
     "test": "node ./node_modules/vscode/bin/test",
     "vscode:prepublish": "npm run compile"

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -23,22 +23,26 @@ export function getFixturePath(file: string[]) {
 	);
 }
 
+export function delay(ms: number) {
+	return new Promise<void>(function (resolve) {
+		setTimeout(resolve, ms);
+	});
+}
+
 async function getTextEditorOptions() {
 	let resolved = false;
 
-	return new Promise<TextEditorOptions>(resolve => {
+	return new Promise<TextEditorOptions>(async (resolve) => {
 		window.onDidChangeTextEditorOptions(e => {
 			resolved = true;
 			assert.ok(e.options);
 			resolve(e.options);
 		});
-
-		setTimeout(() => {
-			if (resolved) {
-				return;
-			}
-			assert.ok(window.activeTextEditor.options);
-			resolve(window.activeTextEditor.options);
-		}, 100);
+		await delay(100);
+		if (resolved) {
+			return;
+		}
+		assert.ok(window.activeTextEditor.options);
+		resolve(window.activeTextEditor.options);
 	});
 }


### PR DESCRIPTION
Additionally,  I made the following changes: 
- Corrected the scripts in `package.json`. 
- `vscode` for testing doesn't need to be downloaded every time a compilation is triggered.
- Corrected the `test` messages as a test message is displays when test fails.
- Added `os.EOL` so tests can be run correctly also on `Windows`. 