### PR TITLE
Automatically displaying property values when editing .editorconfig

### DIFF
--- a/src/EditorConfigCompletionProvider.ts
+++ b/src/EditorConfigCompletionProvider.ts
@@ -1,9 +1,11 @@
 import {
+	Command,
 	CompletionItemProvider,
 	CompletionItem,
-	CompletionItemKind
+	CompletionItemKind,
+	Position,
+	TextDocument
 } from 'vscode';
-import { TextDocument, Position } from 'vscode';
 
 class EditorConfigCompletionProvider implements CompletionItemProvider {
 
@@ -220,6 +222,13 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 		properties: Property[],
 		textOfEntireLine: string
 	): CompletionItem[] {
+
+		const triggerSuggestCommand: Command = {
+			command: 'editorconfig._triggerSuggestAfterDelay',
+			arguments: [],
+			title: ''
+		};
+
 		return properties.map(property => {
 			// basic info
 			const completionItem = new CompletionItem(
@@ -229,8 +238,10 @@ class EditorConfigCompletionProvider implements CompletionItemProvider {
 			completionItem.documentation = property.description;
 
 			// append equals sign if line does not have one
+			// also automatically displays IntelliSense for property values
 			if (!this.hasEqualsSign(textOfEntireLine)) {
 				completionItem.insertText = property.name + ' = ';
+				completionItem.command = triggerSuggestCommand;
 			}
 
 			return completionItem;

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -24,6 +24,17 @@ export function activate(ctx: ExtensionContext): void {
 		new EditorConfigCompletionProvider()
 	);
 
+	// register an internal command used to automatically display IntelliSense
+	// when editing a .editorconfig file
+	commands.registerCommand(
+		'editorconfig._triggerSuggestAfterDelay',
+		() => {
+			setTimeout(function () {
+				commands.executeCommand('editor.action.triggerSuggest');
+			}, 100);
+		}
+	);
+
 	// register a command handler to generate a .editorconfig file
 	commands.registerCommand(
 		'vscode.generateeditorconfig',


### PR DESCRIPTION
This PR automatically triggers IntelliSense to select a property value after selecting the property key without the need to press Ctrl+Space.

![editorconfig-vscode-autocomplete-improvements](https://cloud.githubusercontent.com/assets/1139781/23595127/3322c948-01fe-11e7-9a27-1a33efff5d2c.gif)
