### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+- Automatically display property values when editing `.editorconfig` ([#109](https://github.com/editorconfig/editorconfig-vscode/pull/109)).
+- Add recommended extensions ([#110](https://github.com/editorconfig/editorconfig-vscode/pull/110)).
+
 ## 0.5.0
 - Added auto-complete improvements ([#103](https://github.com/editorconfig/editorconfig-vscode/pull/103)).
 - Lighten distribution package ([#104](https://github.com/editorconfig/editorconfig-vscode/pull/104)).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.6.0"


### PR DESCRIPTION
## 0.6.0
- [x] Automatically display property values when editing `.editorconfig` ([#109](https://github.com/editorconfig/editorconfig-vscode/pull/109)).
- [x] Add recommended extensions ([#110](https://github.com/editorconfig/editorconfig-vscode/pull/110)).
