### PR TITLE
v0.6.1: Set EOL just before file save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1
+- Set EOL just before file save.
+
 ## 0.6.0
 - Automatically display property values when editing `.editorconfig` ([#109](https://github.com/editorconfig/editorconfig-vscode/pull/109)).
 - Add recommended extensions ([#110](https://github.com/editorconfig/editorconfig-vscode/pull/110)).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.6.0"

--- a/src/transformations/endOfLine.ts
+++ b/src/transformations/endOfLine.ts
@@ -1,26 +1,25 @@
 import * as editorconfig from 'editorconfig';
-import {
-	EndOfLine,
-	TextEditor
-} from 'vscode';
+import { EndOfLine, TextDocument } from 'vscode';
+
+import { findEditor } from '../Utils';
 
 /**
  * Transform the textdocument by setting the end of line sequence
  */
-export function transform(
+export async function transform(
 	editorconfig: editorconfig.knownProps,
-	editor: TextEditor
-): Thenable<boolean|void> {
+	textDocument: TextDocument
+) {
 	const eol = {
 		lf: EndOfLine.LF,
 		crlf: EndOfLine.CRLF
 	}[(editorconfig.end_of_line || '').toLowerCase()];
 
 	if (!eol) {
-		return Promise.resolve();
+		return Promise.resolve(false);
 	}
 
-	return editor.edit(edit => {
+	return findEditor(textDocument).edit(edit => {
 		edit.setEndOfLine(eol);
 	});
 }

--- a/test/fixtures/end_of_line/preserve/.editorconfig
+++ b/test/fixtures/end_of_line/preserve/.editorconfig
@@ -1,4 +1,0 @@
-root = true
-
-[*]
-end_of_line = preserve

--- a/test/fixtures/end_of_line/unset/.editorconfig
+++ b/test/fixtures/end_of_line/unset/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = unset

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -23,10 +23,12 @@ export function getFixturePath(file: string[]) {
 	);
 }
 
-export function delay(ms: number) {
-	return new Promise<void>(function (resolve) {
-		setTimeout(resolve, ms);
-	});
+/**
+ * Waits for a specified amount of time, specified in milliseconds.
+ * @param wait The number of milliseconds to wait.
+ */
+export function wait(ms?: number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function getTextEditorOptions() {
@@ -38,7 +40,7 @@ async function getTextEditorOptions() {
 			assert.ok(e.options);
 			resolve(e.options);
 		});
-		await delay(100);
+		await wait(100);
 		if (resolved) {
 			return;
 		}


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

