### PR TITLE
v0.6.2: Save/restore selections (cursors) during file save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.2
+- Save/restore selections (cursors) during file save.
+
 ## 0.6.1
 - Set EOL just before file save.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.6.0"

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -135,7 +135,17 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	private onWillSaveTextDocument(e: TextDocumentWillSaveEvent) {
-		e.waitUntil(this.calculatePreSaveTransformations(e.document));
+		let selections: Selection[];
+		if (window.activeTextEditor.document === e.document) {
+			selections = window.activeTextEditor.selections;
+		}
+		const transformations = this.calculatePreSaveTransformations(e.document);
+		e.waitUntil(transformations);
+		if (selections) {
+			transformations.then(() => {
+				window.activeTextEditor.selections = selections;
+			});
+		}
 	}
 
 	private async calculatePreSaveTransformations(


### PR DESCRIPTION
Fixes #83 

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

