### PR TITLE
v0.6.3: Undo pre-save EOL, add output window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.3
+- Undo setting of EOL just before file save.
+  - Wasn't working on background files.
+  - Waiting for [March vscode API updates](https://github.com/Microsoft/vscode/issues/15510#issuecomment-286034612) to fix properly.
+
 ## 0.6.2
 - Save/restore selections (cursors) during file save.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.6.0"

--- a/src/transformations/endOfLine.ts
+++ b/src/transformations/endOfLine.ts
@@ -1,14 +1,12 @@
 import * as editorconfig from 'editorconfig';
-import { EndOfLine, TextDocument } from 'vscode';
-
-import { findEditor } from '../Utils';
+import { EndOfLine, TextEditor } from 'vscode';
 
 /**
  * Transform the textdocument by setting the end of line sequence
  */
 export async function transform(
 	editorconfig: editorconfig.knownProps,
-	textDocument: TextDocument
+	editor: TextEditor
 ) {
 	const eol = {
 		lf: EndOfLine.LF,
@@ -16,10 +14,10 @@ export async function transform(
 	}[(editorconfig.end_of_line || '').toLowerCase()];
 
 	if (!eol) {
-		return Promise.resolve(false);
+		return false;
 	}
 
-	return findEditor(textDocument).edit(edit => {
+	return await editor.edit(edit => {
 		edit.setEndOfLine(eol);
 	});
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,6 +13,8 @@ import {
 
 import * as utils from 'vscode-test-utils';
 
+import { wait } from './testUtils';
+
 suite('EditorConfig extension', () => {
 
 	suiteTeardown(utils.closeAllFiles);
@@ -110,51 +112,51 @@ suite('EditorConfig extension', () => {
 	});
 
 	test('end_of_line = lf', async () => {
-		const savedText = await withSetting(
+		const doc = await withSetting(
 			'end_of_line',
 			'lf',
 			{
-				contents: 'bar\r\n'
+				contents: 'foo\r\n'
 			}
-		).saveText('foo\r\n');
-		assert.strictEqual(savedText, 'foo\nbar\n',
-			'editor fails to convert CRLF line endings into LF on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\n',
+			'editor fails to convert CRLF line endings into LF on open');
 	});
 
 	test('end_of_line = crlf', async () => {
-		const savedText = await withSetting(
+		const doc = await withSetting(
 			'end_of_line',
 			'crlf',
 			{
-				contents: 'bar\n'
+				contents: 'foo\n'
 			}
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\r\nbar\r\n',
-			'editor fails to convert LF line endings into CRLF on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\r\n',
+			'editor fails to convert LF line endings into CRLF on open');
 	});
 
 	test('end_of_line = unset', async () => {
-		const savedText = await withSetting(
+		const doc = await withSetting(
 			'end_of_line',
 			'unset',
 			{
-				contents: 'bar\n'
+				contents: 'foo\n'
 			}
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\nbar\n',
-			'editor fails to preserve CRLF line endings on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\n',
+			'editor fails to preserve CRLF line endings on open');
 	});
 
 	test('end_of_line is undefined', async () => {
-		const savedText = await withSetting(
+		const doc = await withSetting(
 			'end_of_line',
 			'undefined',
 			{
-				contents: 'bar\n'
+				contents: 'foo\n'
 			}
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\nbar\n',
-			'editor fails to preserve CRLF line endings on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\n',
+			'editor fails to preserve CRLF line endings on open');
 	});
 
 	test('detect indentation', async () => {
@@ -184,6 +186,7 @@ function withSetting(
 	} = {}
 ) {
 	return {
+		doc: createDoc(options.contents),
 		saveText: (text: string) => new Promise(async resolve => {
 			const doc = await createDoc(options.contents);
 			workspace.onDidSaveTextDocument(savedDoc => {
@@ -208,6 +211,7 @@ function withSetting(
 		]));
 		const doc = await workspace.openTextDocument(filename);
 		await window.showTextDocument(doc);
+		await wait(50);
 		return doc;
 	}
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

## Changelog v0.6.3
- Undo setting of EOL just before file save.
  - Wasn't working on background files.
  - Waiting for [March vscode API updates](https://github.com/Microsoft/vscode/issues/15510#issuecomment-286034612) to fix properly.
- Added an output window to track how configurations are applied.
