### PR TITLE
Revert "v0.6.1: Set EOL just before file save"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 0.6.1
-- Set EOL just before file save.
-
 ## 0.6.0
 - Automatically display property values when editing `.editorconfig` ([#109](https://github.com/editorconfig/editorconfig-vscode/pull/109)).
 - Add recommended extensions ([#110](https://github.com/editorconfig/editorconfig-vscode/pull/110)).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.1",
+  "version": "0.6.0",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.6.0"

--- a/src/transformations/endOfLine.ts
+++ b/src/transformations/endOfLine.ts
@@ -1,25 +1,26 @@
 import * as editorconfig from 'editorconfig';
-import { EndOfLine, TextDocument } from 'vscode';
-
-import { findEditor } from '../Utils';
+import {
+	EndOfLine,
+	TextEditor
+} from 'vscode';
 
 /**
  * Transform the textdocument by setting the end of line sequence
  */
-export async function transform(
+export function transform(
 	editorconfig: editorconfig.knownProps,
-	textDocument: TextDocument
-) {
+	editor: TextEditor
+): Thenable<boolean|void> {
 	const eol = {
 		lf: EndOfLine.LF,
 		crlf: EndOfLine.CRLF
 	}[(editorconfig.end_of_line || '').toLowerCase()];
 
 	if (!eol) {
-		return Promise.resolve(false);
+		return Promise.resolve();
 	}
 
-	return findEditor(textDocument).edit(edit => {
+	return editor.edit(edit => {
 		edit.setEndOfLine(eol);
 	});
 }

--- a/test/fixtures/end_of_line/preserve/.editorconfig
+++ b/test/fixtures/end_of_line/preserve/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = preserve

--- a/test/fixtures/end_of_line/unset/.editorconfig
+++ b/test/fixtures/end_of_line/unset/.editorconfig
@@ -1,4 +1,0 @@
-root = true
-
-[*]
-end_of_line = unset

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
 import * as os from 'os';
+import * as assert from 'assert';
 import {
 	Position,
 	window,
@@ -8,7 +8,8 @@ import {
 } from 'vscode';
 import {
 	getFixturePath,
-	getOptionsForFixture
+	getOptionsForFixture,
+	delay
 } from './testUtils';
 
 import * as utils from 'vscode-test-utils';
@@ -51,10 +52,7 @@ suite('EditorConfig extension', () => {
 
 	test('subfolder settings', async () => {
 		for (const n of [2, 3, 4, 'x']) {
-			const options = await getOptionsForFixture([
-				'folder',
-				`tab-width-${n}`
-			]);
+			const options = await getOptionsForFixture(['folder', `tab-width-${n}`]);
 			const expectedTabSize = (n === 'x') ? 8 : n;
 			assert.strictEqual(
 				options.insertSpaces,
@@ -64,10 +62,7 @@ suite('EditorConfig extension', () => {
 			assert.strictEqual(
 				options.tabSize,
 				expectedTabSize,
-				[
-					`editor has a tabSize of ${options.tabSize}`,
-					`instead of ${expectedTabSize}`
-				].join(' ')
+				`editor has a tabSize of ${options.tabSize} instead of ${expectedTabSize}`
 			);
 		}
 	});
@@ -110,51 +105,51 @@ suite('EditorConfig extension', () => {
 	});
 
 	test('end_of_line = lf', async () => {
-		const savedText = await withSetting(
+		const doc = await withSetting(
 			'end_of_line',
 			'lf',
 			{
-				contents: 'bar\r\n'
+				contents: 'foo\r\n'
 			}
-		).saveText('foo\r\n');
-		assert.strictEqual(savedText, 'foo\nbar\n',
-			'editor fails to convert CRLF line endings into LF on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\n',
+			'editor fails to convert CRLF line endings into LF on open');
 	});
 
 	test('end_of_line = crlf', async () => {
-		const savedText = await withSetting(
+		const doc = await withSetting(
 			'end_of_line',
 			'crlf',
 			{
-				contents: 'bar\n'
+				contents: 'foo\n'
 			}
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\r\nbar\r\n',
-			'editor fails to convert LF line endings into CRLF on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\r\n',
+			'editor fails to convert LF line endings into CRLF on open');
 	});
 
-	test('end_of_line = unset', async () => {
-		const savedText = await withSetting(
+	test('end_of_line = preserve', async () => {
+		const doc = await withSetting(
 			'end_of_line',
-			'unset',
+			'preserve',
 			{
-				contents: 'bar\n'
+				contents: 'foo\r\n'
 			}
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\nbar\n',
-			'editor fails to preserve CRLF line endings on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\r\n',
+			'editor fails to preserve CRLF line endings on open');
 	});
 
-	test('end_of_line is undefined', async () => {
-		const savedText = await withSetting(
+	test('end_of_line = undefined', async () => {
+		const doc = await withSetting(
 			'end_of_line',
 			'undefined',
 			{
-				contents: 'bar\n'
+				contents: 'foo\r\n'
 			}
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\nbar\n',
-			'editor fails to preserve CRLF line endings on save');
+		).doc;
+		assert.strictEqual(doc.getText(), 'foo\r\n',
+			'editor fails to preserve CRLF line endings on open');
 	});
 
 	test('detect indentation', async () => {
@@ -179,35 +174,41 @@ suite('EditorConfig extension', () => {
 function withSetting(
 	rule: string,
 	value: string,
-	options: {
-		contents?: string
-	} = {}
+	options?: {
+		contents?: string;
+		saves?: number;
+	}
 ) {
+	options = options || {};
 	return {
-		saveText: (text: string) => new Promise(async resolve => {
-			const doc = await createDoc(options.contents);
-			workspace.onDidSaveTextDocument(savedDoc => {
-				resolve(savedDoc.getText());
+		doc: createDoc(options.contents),
+		saveText: async (text: string) => {
+			return await new Promise<string>(async (resolve) => {
+				const doc = await createDoc();
+				const edit = new WorkspaceEdit();
+				edit.insert(doc.uri, new Position(0, 0), text);
+				assert.strictEqual(
+					await workspace.applyEdit(edit),
+					true,
+					'editor fails to apply edit'
+				);
+				workspace.onDidSaveTextDocument(savedDoc => {
+					resolve(savedDoc.getText());
+				});
+				workspace.onDidChangeTextDocument(doc.save);
 			});
-			workspace.onDidChangeTextDocument(doc.save);
-			const edit = new WorkspaceEdit();
-			edit.insert(doc.uri, new Position(0, 0), text);
-			assert.strictEqual(
-				await workspace.applyEdit(edit),
-				true,
-				'editor fails to apply edit'
-			);
-		})
+		}
 	};
 
-	async function createDoc(contents: string = '') {
-		const filename = await utils.createFile(contents, getFixturePath([
+	async function createDoc(contents?: string) {
+		const filename = await utils.createFile(contents || '', getFixturePath([
 			rule,
 			value,
 			'test'
 		]));
 		const doc = await workspace.openTextDocument(filename);
 		await window.showTextDocument(doc);
+		await delay(50);
 		return doc;
 	}
 }

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -23,12 +23,10 @@ export function getFixturePath(file: string[]) {
 	);
 }
 
-/**
- * Waits for a specified amount of time, specified in milliseconds.
- * @param wait The number of milliseconds to wait.
- */
-export function wait(ms?: number) {
-	return new Promise(resolve => setTimeout(resolve, ms));
+export function delay(ms: number) {
+	return new Promise<void>(function (resolve) {
+		setTimeout(resolve, ms);
+	});
 }
 
 async function getTextEditorOptions() {
@@ -40,7 +38,7 @@ async function getTextEditorOptions() {
 			assert.ok(e.options);
 			resolve(e.options);
 		});
-		await wait(100);
+		await delay(100);
 		if (resolved) {
 			return;
 		}


### PR DESCRIPTION
Reverts editorconfig/editorconfig-vscode#116

This was causing issues on dirty files in the background. Reverting until March vscode API updates.