### PR TITLE
v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.3
+- Use new `TextEdit.setEndOfLine` API.
+- Preserve selections on file save.
+- Demote warning message to output channel.
+
 ## 0.6.2
 - Save/restore selections (cursors) during file save.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.11.0"


### PR DESCRIPTION
## 0.6.3
- Use new `TextEdit.setEndOfLine` API.
- Preserve selections on file save.
- Demote warning message to output channel.

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

