### PR TITLE
v0.6.5: Restore manual trims on inactive docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.5
+- Restore non-native trailing whitespace trims on inactive editor documents (save all).
+
 ## 0.6.4
 - Use native `editor.action.trimTrailingWhitespace`.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.11.0"

--- a/src/transformations/TrimTrailingWhitespace.ts
+++ b/src/transformations/TrimTrailingWhitespace.ts
@@ -1,11 +1,13 @@
 import * as editorconfig from 'editorconfig';
 import {
+	commands,
 	workspace,
 	TextDocument,
 	TextLine,
 	Position,
 	Range,
-	TextEdit
+	TextEdit,
+	window
 } from 'vscode';
 
 import PreSaveTransformation from './PreSaveTransformation';
@@ -29,6 +31,11 @@ class TrimTrailingWhitespace extends PreSaveTransformation {
 		}
 
 		if (!editorconfig.trim_trailing_whitespace) {
+			return [];
+		}
+
+		if (window.activeTextEditor.document === doc) {
+			commands.executeCommand('editor.action.trimTrailingWhitespace');
 			return [];
 		}
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -181,6 +181,7 @@ function withSetting(
 				const doc = await createDoc(options.contents);
 				workspace.onDidChangeTextDocument(doc.save);
 				workspace.onDidSaveTextDocument(savedDoc => {
+					assert.strictEqual(savedDoc.isDirty, false, 'dirty saved doc');
 					resolve(savedDoc.getText());
 				});
 				const edit = new WorkspaceEdit();


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

