### PR TITLE
v0.7.0: Assume new/untitled docs are @ root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.7.0
+- Assume new/untitled docs are @ root path.
+
 ## 0.6.5
 - Restore non-native trailing whitespace trims on inactive editor documents (save all).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.11.0"

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -84,7 +84,13 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	public getSettingsForDocument(doc: TextDocument) {
-		return this.docToConfigMap[doc.fileName];
+		return this.docToConfigMap[this.getFileName(doc)];
+	}
+
+	private getFileName(doc: TextDocument) {
+		return (doc.isUntitled)
+			? path.join(workspace.rootPath, doc.fileName)
+			: doc.fileName;
 	}
 
 	public getDefaultSettings() {
@@ -100,11 +106,7 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	private async onDidOpenDocument(doc: TextDocument) {
-		if (doc.isUntitled) {
-			this.log('Skipped untitled document.');
-			return;
-		}
-		const fileName = doc.fileName;
+		const fileName = this.getFileName(doc);
 		const relativePath = workspace.asRelativePath(fileName);
 		this.log(`Applying configuration to ${relativePath}...`);
 


### PR DESCRIPTION
## 0.7.0
- Assume new/untitled docs are @ root path.

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

