### PR TITLE
v0.8.0: Use default language extension for untitled documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.0
+- Use default language extension for untitled documents.
+
 ## 0.7.0
 - Assume new/untitled docs are @ root path.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.11.0"

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -10,6 +10,7 @@ import {
 	TextEditorOptions,
 	TextEdit
 } from 'vscode';
+import languageExtensionMap from './languageExtensionMap';
 import { fromEditorConfig } from './Utils';
 import {
 	InsertFinalNewline,
@@ -88,9 +89,11 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	private getFileName(doc: TextDocument) {
-		return (doc.isUntitled)
-			? path.join(workspace.rootPath, doc.fileName)
-			: doc.fileName;
+		if (!doc.isUntitled) {
+			return doc.fileName;
+		}
+		const ext = languageExtensionMap[doc.languageId] || doc.languageId;
+		return path.join(workspace.rootPath, `${doc.fileName}.${ext}`);
 	}
 
 	public getDefaultSettings() {
@@ -106,6 +109,9 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	private async onDidOpenDocument(doc: TextDocument) {
+		if (doc.languageId === 'Log') {
+			return;
+		}
 		const fileName = this.getFileName(doc);
 		const relativePath = workspace.asRelativePath(fileName);
 		this.log(`Applying configuration to ${relativePath}...`);

--- a/src/languageExtensionMap.ts
+++ b/src/languageExtensionMap.ts
@@ -1,0 +1,11 @@
+export default {
+	javascript: 'js',
+	javascriptreact: 'jsx',
+	markdown: 'md',
+	plaintext: 'txt',
+	python: 'py',
+	ruby: 'rb',
+	typescript: 'ts',
+	typescriptreact: 'tsx',
+	yaml: 'yml'
+};


### PR DESCRIPTION
Untitled documents don't have a lot of information about them, so it's difficult to provided a meaningful EditorConfig configuration, but there are some tidbits we can use, like the `doc.languageId`, which tells us the selected language for the untitled document. Combine that with the root file path and we can get a general idea of the desired configuration for the file in question.

