### PR TITLE
Fix 'document' of undefined when extension debug execution

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -60,14 +60,15 @@ class DocumentWatcher implements EditorConfigProvider {
 
 		subscriptions.push(workspace.onWillSaveTextDocument(async e => {
 			let selections: Selection[];
-			if (window.activeTextEditor.document === e.document) {
-				selections = window.activeTextEditor.selections;
+			const activeTextEditor = window.activeTextEditor;
+			if (activeTextEditor && activeTextEditor.document === e.document) {
+				selections = activeTextEditor.selections;
 			}
 			const transformations = this.calculatePreSaveTransformations(e.document);
 			e.waitUntil(transformations);
 			if (selections) {
 				transformations.then(() => {
-					window.activeTextEditor.selections = selections;
+					activeTextEditor.selections = selections;
 				});
 			}
 		}));


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

---

I catched an error while debugging an extension.

```
TypeError: Cannot read property 'document' of undefined
    at DocumentWatcher.<anonymous> (/Users/a14816/.vscode/extensions/EditorConfig.editorconfig-0.9.3/out/src/DocumentWatcher.js:41:49)
    at Generator.next (<anonymous>)
    at __awaiter (/Users/a14816/.vscode/extensions/EditorConfig.editorconfig-0.9.3/out/src/DocumentWatcher.js:6:71)
    at __awaiter (/Users/a14816/.vscode/extensions/EditorConfig.editorconfig-0.9.3/out/src/DocumentWatcher.js:2:12)
    at __dirname.constructor.subscriptions.push.vscode_1.workspace.onWillSaveTextDocument (/Users/a14816/.vscode/extensions/EditorConfig.editorconfig-0.9.3/out/src/DocumentWatcher.js:39:77)
    at t._deliverEventAsync (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:293865)
    at t._deliverEventAsyncAndBlameBadListeners (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:293397)
    at /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:293082
    at t (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:74068)
    at n (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:74128)
    at n.Class.define.cancel.then (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:69267)
    at Object.h [as sequence] (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:74218)
    at t.$participateInSave (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:292956)
    at t.e.handle (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:266424)
    at s (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:154927)
    at h (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/node/extensionHostProcess.js:4:155604)
```

It seems that `activeTextEditor` becomes `undefined` when debug execution.
`activeTextEditor` existence checked in example on [VS Code Blog](https://code.visualstudio.com/blogs/2016/11/15/formatters-best-practices).