### PR TITLE
DocumentWatcher should check validity of window.activeTextEditor

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -61,7 +61,7 @@ class DocumentWatcher implements EditorConfigProvider {
 		subscriptions.push(workspace.onWillSaveTextDocument(async e => {
 			let selections: Selection[];
 			if (window.activeTextEditor !== undefined &&
-			    window.activeTextEditor.document === e.document) {
+				window.activeTextEditor.document === e.document) {
 				selections = window.activeTextEditor.selections;
 			}
 			const transformations = this.calculatePreSaveTransformations(e.document);

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -60,7 +60,8 @@ class DocumentWatcher implements EditorConfigProvider {
 
 		subscriptions.push(workspace.onWillSaveTextDocument(async e => {
 			let selections: Selection[];
-			if (window.activeTextEditor !== undefined && window.activeTextEditor.document === e.document) {
+			if (window.activeTextEditor !== undefined &&
+			    window.activeTextEditor.document === e.document) {
 				selections = window.activeTextEditor.selections;
 			}
 			const transformations = this.calculatePreSaveTransformations(e.document);

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -60,7 +60,7 @@ class DocumentWatcher implements EditorConfigProvider {
 
 		subscriptions.push(workspace.onWillSaveTextDocument(async e => {
 			let selections: Selection[];
-			if (window.activeTextEditor.document === e.document) {
+			if (window.activeTextEditor !== undefined && window.activeTextEditor.document === e.document) {
 				selections = window.activeTextEditor.selections;
 			}
 			const transformations = this.calculatePreSaveTransformations(e.document);


### PR DESCRIPTION
A file may be saved by an extension outside of the context of the editor.  If there is no active file open in the editor, you can't test against it.
Issue #155

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [ ] Run `tsc` w/o errors (same as `npm run compile`).
- [ ] Run `npm run lint` w/o errors.

