### PR TITLE
v0.9.4: Fix document of undefined error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.4
+- Fix `document` of `undefined` error.
+
 ## 0.9.3
 - Fix workspace issue on Linux [`#145`](https://github.com/editorconfig/editorconfig-vscode/issues/145).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.11.0"

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -1,5 +1,6 @@
 import * as editorconfig from 'editorconfig';
 import * as compact from 'lodash.compact';
+import * as get from 'lodash.get';
 import * as path from 'path';
 import {
 	window,
@@ -60,15 +61,18 @@ class DocumentWatcher implements EditorConfigProvider {
 
 		subscriptions.push(workspace.onWillSaveTextDocument(async e => {
 			let selections: Selection[];
-			if (window.activeTextEditor !== undefined &&
-				window.activeTextEditor.document === e.document) {
+			const activeEditor = window.activeTextEditor;
+			const activeDoc = get(activeEditor, 'document');
+			if (activeDoc && activeDoc === e.document) {
 				selections = window.activeTextEditor.selections;
 			}
-			const transformations = this.calculatePreSaveTransformations(e.document);
+			const transformations = this.calculatePreSaveTransformations(
+				e.document
+			);
 			e.waitUntil(transformations);
 			if (selections) {
 				transformations.then(() => {
-					window.activeTextEditor.selections = selections;
+					activeEditor.selections = selections;
 				});
 			}
 		}));


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

