### PR TITLE
Enable only when .editorconfig file exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "*"
+    "workspaceContains:.editorconfig"
   ],
   "main": "./out/src/editorConfigMain",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "workspaceContains:.editorconfig"
+    "workspaceContains:**/.editorconfig"
   ],
   "main": "./out/src/editorConfigMain",
   "contributes": {


### PR DESCRIPTION
Hello :-)

This PR does:

- Activate editorconfig extension only when `.editorconfig` file exist on workspace.

I did this because I noticed that editorconfig is always activated, It's executing even when `.editorconfig` doesn't exist.

![screenshot_20170719_171244](https://user-images.githubusercontent.com/3067335/28392005-c6b5476e-6ca5-11e7-8cd4-f14f6312f22a.png)

![screenshot_20170719_171653](https://user-images.githubusercontent.com/3067335/28392168-6682dcd4-6ca6-11e7-8b30-9c47d869b6bf.png)


