### PR TITLE
Reworked InsertFinalNewline class

### DIFF
--- a/src/transformations/InsertFinalNewline.ts
+++ b/src/transformations/InsertFinalNewline.ts
@@ -83,18 +83,16 @@ export default class InsertFinalNewline extends PreSaveTransformation {
 			return this.doNothing();
 		}
 
-		if (editorconfigProperties.insert_final_newline) {
-			if (lastLine.isEmptyOrWhitespace) {
-				return this.doNothing();
-			} else {
+		if (editorconfigProperties.insert_final_newline
+			&& !lastLine.isEmptyOrWhitespace) {
 				return this.insertFinalNewline(editorconfigProperties, doc);
-			}
-		} else {
-			if (lastLine.isEmptyOrWhitespace) {
-				return this.deleteFinalNewlines(doc);
-			} else {
-				return this.doNothing();
-			}
 		}
+
+		if (!editorconfigProperties.insert_final_newline
+			&& lastLine.isEmptyOrWhitespace) {
+			return this.deleteFinalNewlines(doc);
+		}
+
+		return this.doNothing();
 	}
 }

--- a/src/transformations/InsertFinalNewline.ts
+++ b/src/transformations/InsertFinalNewline.ts
@@ -3,6 +3,7 @@ import * as editorconfig from 'editorconfig';
 import {
 	TextDocument,
 	Position,
+	Range,
 	TextEdit
 } from 'vscode';
 
@@ -23,22 +24,59 @@ export default class InsertFinalNewline extends PreSaveTransformation {
 		const lineCount = doc.lineCount;
 		const lastLine = doc.lineAt(lineCount - 1);
 
-		if (!editorconfigProperties.insert_final_newline
-			|| lineCount === 0
-			|| lastLine.isEmptyOrWhitespace) {
+		if (lineCount === 0) {
 			return { edits: [] };
 		}
 
-		const position = new Position(
-			lastLine.lineNumber,
-			lastLine.text.length
-		);
+		if (editorconfigProperties.insert_final_newline) {
+			if (lastLine.isEmptyOrWhitespace) {
+				return { edits: [] };
+			} else {
+				const position = new Position(
+					lastLine.lineNumber,
+					lastLine.text.length
+				);
 
-		const eol = get(editorconfigProperties, 'end_of_line', 'lf').toUpperCase();
+				const eol = get(editorconfigProperties, 'end_of_line', 'lf').toUpperCase();
 
-		return {
-			edits: [ TextEdit.insert(position, this.lineEndings[eol]) ],
-			message: `insertFinalNewline(${eol})`
-		};
+				return {
+					edits: [ TextEdit.insert(position, this.lineEndings[eol]) ],
+					message: `insertFinalNewline(${eol})`
+				};
+			}
+		} else {
+			if (lastLine.isEmptyOrWhitespace) {
+				let realLastLine = lastLine;
+				let realLastLineDetected = false;
+				let lineCounter = 1;
+
+				while (!realLastLineDetected) {
+					if (!realLastLine.isEmptyOrWhitespace) {
+						realLastLineDetected = true;
+					} else {
+						lineCounter++;
+						realLastLine = doc.lineAt(lineCount - lineCounter);
+					}
+				}
+
+				const rangeStart = realLastLine.range;
+				const rangeEnd = lastLine.range;
+
+				const positionStart = rangeStart[Object.keys(rangeStart)[1]];
+				const positionEnd = rangeEnd[Object.keys(rangeEnd)[1]];
+
+				const range = new Range(
+					positionStart,
+					positionEnd
+				);
+
+				return {
+					edits: [ TextEdit.delete(range) ],
+					message: `deleteRange(${range})`
+				};
+			} else {
+				return { edits: [] };
+			}
+		}
 	}
 }

--- a/src/transformations/InsertFinalNewline.ts
+++ b/src/transformations/InsertFinalNewline.ts
@@ -17,10 +17,7 @@ export default class InsertFinalNewline extends PreSaveTransformation {
 		LF: '\n'
 	};
 
-	private deleteFinalNewlines = (doc) => {
-		const lineCount = doc.lineCount;
-		const lastLine = doc.lineAt(lineCount - 1);
-
+	private deleteFinalNewlines = (doc, lineCount, lastLine) => {
 		let realLastLine = lastLine;
 		let realLastLineDetected = false;
 		let lineCounter = 1;
@@ -55,10 +52,7 @@ export default class InsertFinalNewline extends PreSaveTransformation {
 		return { edits: [] };
 	}
 
-	private insertFinalNewline = (editorconfigProperties, doc) => {
-		const lineCount = doc.lineCount;
-		const lastLine = doc.lineAt(lineCount - 1);
-
+	private insertFinalNewline = (editorconfigProperties, lastLine) => {
 		const position = new Position(
 			lastLine.lineNumber,
 			lastLine.text.length
@@ -85,12 +79,12 @@ export default class InsertFinalNewline extends PreSaveTransformation {
 
 		if (editorconfigProperties.insert_final_newline
 			&& !lastLine.isEmptyOrWhitespace) {
-				return this.insertFinalNewline(editorconfigProperties, doc);
+				return this.insertFinalNewline(editorconfigProperties, lastLine);
 		}
 
 		if (!editorconfigProperties.insert_final_newline
 			&& lastLine.isEmptyOrWhitespace) {
-			return this.deleteFinalNewlines(doc);
+			return this.deleteFinalNewlines(doc, lineCount, lastLine);
 		}
 
 		return this.doNothing();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -77,13 +77,12 @@ suite('EditorConfig extension', () => {
 	});
 
 	test('insert_final_newline = false', async () => {
-		const text = `foo${os.EOL}`;
 		const savedText = await withSetting(
 			'insert_final_newline',
 			'false'
-		).saveText(text);
-		assert.strictEqual(savedText, text,
-			'editor fails to preserve final newline on save');
+		).saveText(`foo${os.EOL}`);
+		assert.strictEqual(savedText, `foo`,
+			'editor fails to remove final newline/s on save');
 	});
 
 	test('trim_trailing_whitespace = true', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -107,8 +107,8 @@ suite('EditorConfig extension', () => {
 		const savedText = await withSetting(
 			'end_of_line',
 			'lf',
-		).saveText('foo\r\n');
-		assert.strictEqual(savedText, 'foo\n',
+		).saveText('foo\r\nbar');
+		assert.strictEqual(savedText, 'foo\nbar',
 			'editor fails to convert CRLF line endings into LF on save');
 	});
 
@@ -116,8 +116,8 @@ suite('EditorConfig extension', () => {
 		const savedText = await withSetting(
 			'end_of_line',
 			'crlf'
-		).saveText('foo\n');
-		assert.strictEqual(savedText, 'foo\r\n',
+		).saveText('foo\nbar');
+		assert.strictEqual(savedText, 'foo\r\nbar',
 			'editor fails to convert LF line endings into CRLF on save');
 	});
 
@@ -128,8 +128,8 @@ suite('EditorConfig extension', () => {
 			{
 				contents: '\r\n'
 			}
-		).saveText('foo');
-		assert.strictEqual(savedText, 'foo\r\n',
+		).saveText('foo\r\nbar');
+		assert.strictEqual(savedText, 'foo\r\nbar',
 			'editor fails to preserve CRLF line endings on save');
 	});
 
@@ -140,8 +140,8 @@ suite('EditorConfig extension', () => {
 			{
 				contents: '\r\n'
 			}
-		).saveText('foo');
-		assert.strictEqual(savedText, 'foo\r\n',
+		).saveText('foo\r\nbar');
+		assert.strictEqual(savedText, 'foo\r\nbar',
 			'editor fails to preserve CRLF line endings on save');
 	});
 


### PR DESCRIPTION
Fixes #151 

I've reworked the InsertFinalNewline class to allow it to remove newlines at the end of file if insert_final_newline is set to false.

- [ ] Use a meaningful title for the pull request.
- [ ] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.
