### PR TITLE
Pass an "auto-save" reason to avoid trimming whitespace at the cursor

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -10,7 +10,8 @@ import {
 	TextDocument,
 	TextEditor,
 	TextEditorOptions,
-	TextEdit
+	TextEdit,
+	TextDocumentSaveReason
 } from 'vscode';
 import languageExtensionMap from './languageExtensionMap';
 import { fromEditorConfig } from './Utils';
@@ -67,7 +68,8 @@ class DocumentWatcher implements EditorConfigProvider {
 				selections = window.activeTextEditor.selections;
 			}
 			const transformations = this.calculatePreSaveTransformations(
-				e.document
+				e.document,
+				e.reason
 			);
 			e.waitUntil(transformations);
 			if (selections) {
@@ -188,7 +190,8 @@ class DocumentWatcher implements EditorConfigProvider {
 	}
 
 	private async calculatePreSaveTransformations(
-		doc: TextDocument
+		doc: TextDocument,
+		reason: TextDocumentSaveReason
 	): Promise<TextEdit[]> {
 		const editorconfigSettings = this.getSettingsForDocument(doc);
 		const relativePath = workspace.asRelativePath(doc.fileName);
@@ -203,7 +206,8 @@ class DocumentWatcher implements EditorConfigProvider {
 				transformer => {
 					const { edits, message } = transformer.transform(
 						editorconfigSettings,
-						doc
+						doc,
+						reason
 					);
 					if (edits instanceof Error) {
 						this.log(`${relativePath}: ${edits.message}`);

--- a/src/transformations/PreSaveTransformation.ts
+++ b/src/transformations/PreSaveTransformation.ts
@@ -1,10 +1,11 @@
 import { KnownProps } from 'editorconfig';
-import { TextDocument, TextEdit } from 'vscode';
+import { TextDocument, TextEdit, TextDocumentSaveReason } from 'vscode';
 
 abstract class PreSaveTransformation {
 	abstract transform(
 		editorconfig: KnownProps,
-		doc?: TextDocument
+		doc?: TextDocument,
+		reason?: TextDocumentSaveReason
 	): {
 		edits: TextEdit[] | Error;
 		message?: string;

--- a/src/transformations/TrimTrailingWhitespace.ts
+++ b/src/transformations/TrimTrailingWhitespace.ts
@@ -7,7 +7,8 @@ import {
 	Position,
 	Range,
 	TextEdit,
-	window
+	window,
+	TextDocumentSaveReason
 } from 'vscode';
 
 import PreSaveTransformation from './PreSaveTransformation';
@@ -15,7 +16,8 @@ import PreSaveTransformation from './PreSaveTransformation';
 class TrimTrailingWhitespace extends PreSaveTransformation {
 	transform(
 		editorconfigProperties: KnownProps,
-		doc: TextDocument
+		doc: TextDocument,
+		reason: TextDocumentSaveReason
 	) {
 		const editorTrimsWhitespace = workspace
 			.getConfiguration('files')
@@ -41,7 +43,10 @@ class TrimTrailingWhitespace extends PreSaveTransformation {
 		}
 
 		if (window.activeTextEditor.document === doc) {
-			commands.executeCommand('editor.action.trimTrailingWhitespace');
+			const trimReason =
+				(reason !== TextDocumentSaveReason.Manual) ? 'auto-save' : null;
+			commands.executeCommand('editor.action.trimTrailingWhitespace',
+				{ reason: trimReason });
 			return {
 				edits: [],
 				message: 'editor.action.trimTrailingWhitespace'


### PR DESCRIPTION
This fixes #47, but depends on [vscode PR #35778](https://github.com/Microsoft/vscode/pull/35778) before it will actually do anything. This PR should not be merged until that PR is accepted.