### PR TITLE
Provide fallback for workspace root directory when creating config file. Fixes #187

### DIFF
--- a/src/commands/generateEditorConfig.ts
+++ b/src/commands/generateEditorConfig.ts
@@ -11,7 +11,10 @@ import {
  * current vscode settings.
  */
 export function generateEditorConfig(uri: Uri) {
-	const editorConfigFile = path.join(uri.fsPath, '.editorconfig');
+	// the uri can be null - in this case try to fallback to the
+	const lookupPath: string = (uri !== undefined) ?
+		uri.fsPath : workspace.workspaceFolders[0].uri.fsPath;
+	const editorConfigFile = path.join(lookupPath, '.editorconfig');
 
 	fs.stat(editorConfigFile, (err, stats) => {
 


### PR DESCRIPTION
When command is executed from command palette the URI comes undefined -
to prevent using undefined object provide a fallback to default workspace
directory - a first one that falls back to workspace root and use it to
compute a lookup path for configuration file.

Thanks!

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.
