### PR TITLE
v0.12.1 - Fallback for workspace root when creating config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.1
+- Provide fallback for workspace root directory when creating config file [`#188`](https://github.com/editorconfig/editorconfig-vscode/pull/188).
+
 ## 0.12.0
 - Support multi-root workspaces [`#174`](https://github.com/editorconfig/editorconfig-vscode/issues/174).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.11.1",
+  "version": "0.12.1",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.19.2"

--- a/src/commands/generateEditorConfig.ts
+++ b/src/commands/generateEditorConfig.ts
@@ -1,3 +1,4 @@
+import * as get from 'lodash.get';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -11,9 +12,11 @@ import {
  * current vscode settings.
  */
 export function generateEditorConfig(uri: Uri) {
-	// the uri can be null - in this case try to fallback to the
-	const lookupPath: string = (uri !== undefined) ?
-		uri.fsPath : workspace.workspaceFolders[0].uri.fsPath;
+	const lookupPath = get(
+		uri,
+		'fsPath',
+		get(workspace, 'workspaceFolders[0].uri.fsPath', '.'),
+	);
 	const editorConfigFile = path.join(lookupPath, '.editorconfig');
 
 	fs.stat(editorConfigFile, (err, stats) => {


### PR DESCRIPTION
Follow-up to https://github.com/editorconfig/editorconfig-vscode/pull/188