### PR TITLE
v0.12.6 - Fix unset / detect indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.6
+- Fix support for `unset` by not overriding built-in "detect indentation" functionality [`#201`](https://github.com/editorconfig/editorconfig-vscode/pull/201). Thanks [`@slartibardfast`](https://github.com/slartibardfast)!
+
 ## 0.12.5
 - Update dependencies.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.28.1"


### PR DESCRIPTION
## 0.12.6

- Fix support for `unset` by not overriding built-in "detect indentation" functionality [`#201`](https://github.com/editorconfig/editorconfig-vscode/pull/201). Thanks [`@slartibardfast`](https://github.com/slartibardfast)!