### PR TITLE
v0.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.8
+- **Fix:** Prevent document watcher from trying to load a config for an undefined text document.
+- **Fix:** Generate config with a final newline if it's enabled.
+- Add missing changelog for v0.12.7.
+
+## 0.12.7
+- **Fix:** Respond to external `.editorconfig` edits.
+
 ## 0.12.6
 - Fix support for `unset` by not overriding built-in "detect indentation" functionality [`#201`](https://github.com/editorconfig/editorconfig-vscode/pull/201). Thanks [`@slartibardfast`](https://github.com/slartibardfast)!
 

--- a/README.md
+++ b/README.md
@@ -30,17 +30,23 @@ ext install EditorConfig
 * `indent_style`
 * `indent_size`
 * `tab_width`
-* `end_of_line`
-* `insert_final_newline`
-* `trim_trailing_whitespace`
+* `end_of_line` (on save)
+* `insert_final_newline` (on save)
+* `trim_trailing_whitespace` (on save)
 
 ## On the backlog
 
 * `charset`
 
+## How it works
+
+This extension is activated whenever you open a new text editor, switch tabs into an existing one or focus into the editor you already have open. When activated, it uses [`editorconfig`](https://www.npmjs.com/package/editorconfig) to resolve the configuration for that particular file and applies any relevant editor settings.
+
+_Note: some settings can only be applied on file save, as indicated above._
+
 ## Known Issues
 
-* [`trim_trailing_whitespace = false` is not applied when user/workspace setting of `files.trimTrailingWhitespace` is set to `true`.](https://github.com/editorconfig/editorconfig-vscode/issues/153) 
+* [`trim_trailing_whitespace = false` is not applied when user/workspace setting of `files.trimTrailingWhitespace` is set to `true`.](https://github.com/editorconfig/editorconfig-vscode/issues/153)
 
 [Visual Studio Code]: https://code.visualstudio.com/
 [EditorConfig]: https://editorconfig.org/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.30.2"

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -49,7 +49,7 @@ export default class DocumentWatcher implements EditorConfigProvider {
 		}));
 
 		subscriptions.push(window.onDidChangeWindowState(state => {
-			if (state.focused) {
+			if (state.focused && this.doc) {
 				this.resolveConfig(this.doc);
 			}
 		}));


### PR DESCRIPTION
## 0.12.8
- **Fix:** Prevent document watcher from trying to load a config for an undefined text document.
- **Fix:** Generate config with a final newline if it's enabled.
- Add missing changelog for v0.12.7.

## 0.12.7
- **Fix:** Respond to external `.editorconfig` edits.

Fixes #216 
Fixes #218 
