### PR TITLE
feat: language support (experimental)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -19,12 +19,15 @@ export async function resolveTextEditorOptions(
 		onBeforeResolve?: (relativePath: string) => void
 		onEmptyConfig?: (relativePath: string) => void
 	} = {},
-) {
+): Promise<[TextEditorOptions, ResolvedCoreConfig]> {
 	const editorconfigSettings = await resolveCoreConfig(doc, {
 		onBeforeResolve,
 	})
 	if (editorconfigSettings) {
-		return fromEditorConfig(editorconfigSettings, defaults)
+		return [
+			fromEditorConfig(editorconfigSettings, defaults),
+			editorconfigSettings,
+		]
 	}
 	if (onEmptyConfig) {
 		const rp = resolveFile(doc).relativePath
@@ -32,7 +35,7 @@ export async function resolveTextEditorOptions(
 			onEmptyConfig(rp)
 		}
 	}
-	return {}
+	return [{}, editorconfigSettings]
 }
 
 /**


### PR DESCRIPTION
Experimental implementation of https://github.com/editorconfig/editorconfig/issues/190

## EditorConfig Output Window
```txt
Initializing document watcher...
Detected change in configuration: {}
foo/foo.js: {}
trying to set language: foo
Unknown language id: foo
trying to set language: typescript
success!
foo/.editorconfig: {}
foo/foo.js: {}
```