### PR TITLE
v0.14.1: Fix #234 - Don't cache configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.1
+
+- **Fix:** Don't cache editor configuration, as it can change at any time.
+
 ## 0.13.0
 
 - **New:** Provide APIs to

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "icon": "EditorConfig_icon.png",
   "engines": {
-    "vscode": "^1.37.0"
+    "vscode": "^1.39.0"
   },
   "author": "EditorConfig Team",
   "license": "MIT",


### PR DESCRIPTION
Fixes #234 

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

