### PR TITLE
v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.4
+
+- **Fix:** EditorConfig modifies selection incorrectly when the extension host is busy
+  ([`#236`](https://github.com/editorconfig/editorconfig-vscode/issues/236)).
+
 ## 0.14.3
 
 - **Fix:** unhandled error when generating `.editorconfig`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.41.0"


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

---

## 0.14.4

- **Fix:** EditorConfig modifies selection incorrectly when the extension host is busy
  ([`#236`](https://github.com/editorconfig/editorconfig-vscode/issues/236)).