### PR TITLE
Fix #234 - Pickup vscode's language specific editor settings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.14.2",
+  "version": "0.14.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -128,9 +128,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
-      "integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
+      "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.43.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.14.4",
   "icon": "EditorConfig_icon.png",
   "engines": {
-    "vscode": "^1.41.0"
+    "vscode": "^1.43.0"
   },
   "author": "EditorConfig Team",
   "license": "MIT",
@@ -68,7 +68,7 @@
     "@types/lodash.get": "^4.4.6",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.17",
-    "@types/vscode": "^1.41.0",
+    "@types/vscode": "^1.43.0",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
     "cash-cp": "^0.2.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,11 +11,9 @@ import languageExtensionMap from './languageExtensionMap'
 export async function resolveTextEditorOptions(
 	doc: TextDocument,
 	{
-		defaults = pickWorkspaceDefaults(),
 		onBeforeResolve,
 		onEmptyConfig,
 	}: {
-		defaults?: TextEditorOptions
 		onBeforeResolve?: (relativePath: string) => void
 		onEmptyConfig?: (relativePath: string) => void
 	} = {},
@@ -24,7 +22,7 @@ export async function resolveTextEditorOptions(
 		onBeforeResolve,
 	})
 	if (editorconfigSettings) {
-		return fromEditorConfig(editorconfigSettings, defaults)
+		return fromEditorConfig(editorconfigSettings, pickWorkspaceDefaults(doc))
 	}
 	if (onEmptyConfig) {
 		const rp = resolveFile(doc).relativePath
@@ -66,7 +64,9 @@ export async function applyTextEditorOptions(
 /**
  * Picks EditorConfig-relevant props from the editor's default configuration.
  */
-export function pickWorkspaceDefaults(): {
+export function pickWorkspaceDefaults(
+	doc?: TextDocument,
+): {
 	/**
 	 * The number of spaces a tab is equal to. When `editor.detectIndentation`
 	 * is on, this property value will be `undefined`.
@@ -78,7 +78,7 @@ export function pickWorkspaceDefaults(): {
 	 */
 	insertSpaces?: boolean
 } {
-	const workspaceConfig = workspace.getConfiguration('editor', null)
+	const workspaceConfig = workspace.getConfiguration('editor', doc)
 	const detectIndentation = workspaceConfig.get<boolean>('detectIndentation')
 
 	return detectIndentation


### PR DESCRIPTION
Vscode's language specific settings are ignored because the extension didn't pass the configuration scope while it invokes `workspace.getConfiguration(...)` vscode API to retrieve the default editor settings.

This PR fixes the issue by passing the target `TextDocument` instance as the configuration scope to the vscode API to get the correct editor settings.

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

