### PR TITLE
Fixed code completion for .editorconfig file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
+## 0.15.1
+
+- **Fix:** Fixed code completion for .editorconfig file
+  ([`#270`](https://github.com/editorconfig/editorconfig-vscode/pull/270)).
+
+## 0.15.0
+
+- **New:** Added grammar for .editorconfig file.
+  ([`#269`](https://github.com/editorconfig/editorconfig-vscode/pull/269)).
+
 ## 0.14.4
 
-- **Fix:** EditorConfig modifies selection incorrectly when the extension host is busy
+- **Fix:** EditorConfig modifies selection incorrectly when the extension host
+  is busy
   ([`#236`](https://github.com/editorconfig/editorconfig-vscode/issues/236)).
 
 ## 0.14.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.43.0"

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -18,7 +18,7 @@ export function activate(ctx: ExtensionContext) {
 
 	// register .editorconfig file completion provider
 	const editorConfigFileSelector: DocumentSelector = {
-		language: 'properties',
+		language: 'editorconfig',
 		pattern: '**/.editorconfig',
 		scheme: 'file',
 	}


### PR DESCRIPTION
Fixed code completion for .editorconfig file caused by new grammar for editorconfig.

Updated changelog

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

