### PR TITLE
v0.15.2: Fix #271 - Add link to editorconfig.org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,6 @@ Please fill in this template.
 
 - [ ] Use a meaningful title for the pull request.
 - [ ] Use meaningful commit messages.
-- [ ] Run `tsc` w/o errors (same as `npm run compile`).
+- [ ] Run `tsc` w/o errors (same as `npm run build`).
 - [ ] Run `npm run lint` w/o errors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.2
+
+- **New:** Add link to editorconfig.org while generating .editorconfig file.
+  ([`#271`](https://github.com/editorconfig/editorconfig-vscode/issues/271)).
+
 ## 0.15.1
 
 - **Fix:** Fixed code completion for .editorconfig file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.43.0"

--- a/src/commands/generateEditorConfig.ts
+++ b/src/commands/generateEditorConfig.ts
@@ -38,7 +38,13 @@ export async function generateEditorConfig(uri: Uri) {
 		const editor = workspace.getConfiguration('editor', currentUri)
 		const files = workspace.getConfiguration('files', currentUri)
 
-		const settingsLines = ['root = true', '', '[*]']
+		const settingsLines = [
+			'# EditorConfig is awesome: https://EditorConfig.org',
+			'',
+			'root = true',
+			'',
+			'[*]',
+		]
 		function addSetting(key: string, value?: string | number | boolean): void {
 			if (value !== undefined) {
 				settingsLines.push(`${key} = ${value}`)


### PR DESCRIPTION
while generating .editorconfig file.

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

