### PR TITLE
Support all files that have an `editorconfig` file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
           "EditorConfig",
           "editorconfig"
         ],
-        "filenames": [
-          ".editorconfig"
+        "filenamePatterns": [
+          "*.editorconfig"
         ],
         "configuration": "./editorconfig.language-configuration.json"
       }

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
           "EditorConfig",
           "editorconfig"
         ],
-        "filenamePatterns": [
-          "*.editorconfig"
+        "extensions": [
+          ".editorconfig"
         ],
         "configuration": "./editorconfig.language-configuration.json"
       }


### PR DESCRIPTION
Fixes #281 

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.
