### PR TITLE
Use `workspaceContains` instead so extension is only fired when needed, fixes #284

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "*"
+    "workspaceContains:**/.editorConfig"
   ],
   "main": "./out/editorConfigMain.js",
   "types": "./out/editorConfigMain.d.ts",


### PR DESCRIPTION
Use `workspaceContains` instead so extension is only fired when needed

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

