### PR TITLE
fix: end_of_line rule no longer destroys redo history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.15.3
+
+- **Fix:** end_of_line rule no longer destroys redo history
+  ([`#288`](https://github.com/editorconfig/editorconfig-vscode/issues/288)).
+
+## 0.15.2
+
+- Update dependencies.
+- Remove dependency on `lodash`, `lodash.get`, `cash-cp`.
+
 ## 0.15.1
 
 - **Fix:** Fixed code completion for .editorconfig file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.51.1"

--- a/src/api.ts
+++ b/src/api.ts
@@ -107,8 +107,8 @@ export async function resolveCoreConfig(
 	if (!fileName) {
 		return {}
 	}
-	if (onBeforeResolve && relativePath) {
-		onBeforeResolve(relativePath)
+	if (relativePath) {
+		onBeforeResolve?.(relativePath)
 	}
 	const config = await editorconfig.parse(fileName)
 	if (config.indent_size === 'tab') {

--- a/src/transformations/PreSaveTransformation.ts
+++ b/src/transformations/PreSaveTransformation.ts
@@ -1,10 +1,5 @@
 import { KnownProps } from 'editorconfig'
-import {
-	TextDocument,
-	TextDocumentSaveReason,
-	TextEdit,
-	TextEditor,
-} from 'vscode'
+import { TextDocument, TextDocumentSaveReason, TextEdit } from 'vscode'
 
 export abstract class PreSaveTransformation {
 	public abstract transform(
@@ -12,7 +7,6 @@ export abstract class PreSaveTransformation {
 		doc?: TextDocument,
 		reason?: TextDocumentSaveReason,
 	): {
-		condition?(editor: TextEditor): boolean
 		edits: TextEdit[] | Error
 		message?: string
 	}

--- a/src/transformations/SetEndOfLine.ts
+++ b/src/transformations/SetEndOfLine.ts
@@ -1,5 +1,5 @@
 import { KnownProps } from 'editorconfig'
-import { EndOfLine, TextEdit } from 'vscode'
+import { EndOfLine, TextDocument, TextEdit } from 'vscode'
 
 import { PreSaveTransformation } from './PreSaveTransformation'
 
@@ -8,18 +8,50 @@ const eolMap = {
 	CRLF: EndOfLine.CRLF,
 }
 
+/**
+ * Sets the end of line, but only when there is a reason to do so.
+ * This is to preserve redo history when possible.
+ */
 export class SetEndOfLine extends PreSaveTransformation {
 	private eolMap = eolMap
 
-	public transform(editorconfigProperties: KnownProps) {
+	public transform(editorconfigProperties: KnownProps, doc: TextDocument) {
 		const eolKey = (editorconfigProperties.end_of_line || '').toUpperCase()
 		const eol = this.eolMap[eolKey as keyof typeof eolMap]
 
-		return eol
-			? {
-					edits: [TextEdit.setEndOfLine(eol)],
-					message: `setEndOfLine(${eolKey})`,
-			  }
-			: { edits: [] }
+		if (!eol) {
+			return noEdits()
+		}
+
+		const text = doc.getText()
+		switch (eol) {
+			case EndOfLine.LF:
+				if (/\r\n/.test(text)) {
+					return createEdits()
+				}
+				break
+			case EndOfLine.CRLF:
+				// if there is an LF not preceded by a CR
+				if (/(?<!\r)\n/.test(text)) {
+					return createEdits()
+				}
+				break
+		}
+
+		return noEdits()
+
+		function noEdits() {
+			return { edits: [] }
+		}
+
+		/**
+		 * @warning destroys redo history
+		 */
+		function createEdits() {
+			return {
+				edits: [TextEdit.setEndOfLine(eol)],
+				message: `setEndOfLine(${eolKey})`,
+			}
+		}
 	}
 }


### PR DESCRIPTION
Fixes #288

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

