### PR TITLE
fix: associate all files with extension .editorconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.4
+
+- **Fix:** related all files with extension `.editorconfig` as EditorConfig
+  ([`#281`](https://github.com/editorconfig/editorconfig-vscode/issues/281)).
+
 ## 0.15.3
 
 - **Fix:** end_of_line rule no longer destroys redo history

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.51.1"
@@ -60,13 +60,14 @@
     "languages": [
       {
         "id": "editorconfig",
+        "extensions": [
+          ".editorconfig"
+        ],
         "aliases": [
           "EditorConfig",
           "editorconfig"
         ],
-        "filenames": [
-          ".editorconfig"
-        ],
+        "filenames": [],
         "configuration": "./editorconfig.language-configuration.json"
       }
     ],


### PR DESCRIPTION
Fixes #281

