### PR TITLE
feat: expose configuration settings for template generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.16.0
+
+- **New:** expose configuration settings for template generation
+  ([`#277`](https://github.com/editorconfig/editorconfig-vscode/issues/277)).
+
 ## 0.15.5
 
 - **Fix:** add comments to top of generated `.editorconfig` file

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.51.1"
@@ -42,6 +42,21 @@
         "title": "Generate .editorconfig"
       }
     ],
+    "configuration": {
+      "title": "EditorConfig",
+      "properties": {
+        "editorconfig.generateAuto": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically generates an .editorconfig file according to your current editor settings."
+        },
+        "editorconfig.template": {
+          "type": "string",
+          "default": "default",
+          "description": "If generateAuto is false, this template path will be used for each newly-generated .editorconfig file."
+        }
+      }
+    },
     "menus": {
       "commandPalette": [
         {
@@ -107,7 +122,7 @@
     "clean": "rimraf out",
     "prebuild": "npm run clean",
     "build": "tsc",
-    "postbuild": "cp -r src/test/suite/fixtures out/test/suite",
+    "postbuild": "cp -r src/test/suite/fixtures out/test/suite && cp src/DefaultTemplate.editorconfig out",
     "lint": "eslint src/**/*.ts",
     "pretest": "npm run lint && npm run build",
     "prewatch": "npm run build",

--- a/src/DefaultTemplate.editorconfig
+++ b/src/DefaultTemplate.editorconfig
@@ -1,0 +1,33 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Indentation override for all JS under lib directory
+[lib/**.js]
+indent_style = space
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Fixes #277 

Two new settings are exposed to vscode:

```json
{
    "configuration": {
      "title": "EditorConfig",
      "properties": {
        "editorconfig.generateAuto": {
          "type": "boolean",
          "default": true,
          "description": "Automatically generates an .editorconfig file according to your current editor settings."
        },
        "editorconfig.template": {
          "type": "string",
          "default": "default",
          "description": "If generateAuto is false, this template path will be used for each newly-generated .editorconfig file."
        }
      }
    }
}
```