### PR TITLE
fix: default template path RegExp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.1
+
+- **Fix:** default template path RegExp.
+
 ## 0.16.0
 
 - **New:** expose configuration settings for template generation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.51.1"

--- a/src/commands/generateEditorConfig.ts
+++ b/src/commands/generateEditorConfig.ts
@@ -55,7 +55,7 @@ export async function generateEditorConfig(uri: Uri) {
 			let templateBuffer: Buffer
 			try {
 				templateBuffer = await readFile(
-					/default/i.test(template) ? defaultTemplatePath : template,
+					/^default$/i.test(template) ? defaultTemplatePath : template,
 				)
 			} catch (error) {
 				window.showErrorMessage(


### PR DESCRIPTION
This was breaking if your template path contained the word "default" anywhere in it, which was not the intention.