### PR TITLE
fix: defer to vscode built-in EOL normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.2
+
+- Defer to VSCode's built-in EOL sequence normalization, when appropriate.
+
 ## 0.16.1
 
 - **Fix:** default template path RegExp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "EditorConfig",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "EditorConfig for VS Code",
   "description": "EditorConfig Support for Visual Studio Code",
   "publisher": "EditorConfig",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "icon": "EditorConfig_icon.png",
   "engines": {
     "vscode": "^1.51.1"

--- a/src/transformations/SetEndOfLine.ts
+++ b/src/transformations/SetEndOfLine.ts
@@ -19,39 +19,17 @@ export class SetEndOfLine extends PreSaveTransformation {
 		const eolKey = (editorconfigProperties.end_of_line || '').toUpperCase()
 		const eol = this.eolMap[eolKey as keyof typeof eolMap]
 
-		if (!eol) {
-			return noEdits()
-		}
-
-		const text = doc.getText()
-		switch (eol) {
-			case EndOfLine.LF:
-				if (/\r\n/.test(text)) {
-					return createEdits()
-				}
-				break
-			case EndOfLine.CRLF:
-				// if there is an LF not preceded by a CR
-				if (/(?<!\r)\n/.test(text)) {
-					return createEdits()
-				}
-				break
-		}
-
-		return noEdits()
-
-		function noEdits() {
-			return { edits: [] }
-		}
-
 		/**
-		 * @warning destroys redo history
+		 * VSCode normalizes line endings on every file-save operation
+		 * according to whichever EOL sequence is dominant. If the file already
+		 * has the appropriate dominant EOL sequence, there is nothing more to do,
+		 * so we defer to VSCode's built-in functionality by applying no edits.
 		 */
-		function createEdits() {
-			return {
-				edits: [TextEdit.setEndOfLine(eol)],
-				message: `setEndOfLine(${eolKey})`,
-			}
-		}
+		return doc.eol === eol
+			? { edits: [] }
+			: {
+					edits: [TextEdit.setEndOfLine(eol)],
+					message: `setEndOfLine(${eolKey})`,
+			  }
 	}
 }


### PR DESCRIPTION
Continuation of #292 
Fixes #288 
