### PR TITLE
not set EOL when no EOL config

### DIFF
--- a/src/transformations/SetEndOfLine.ts
+++ b/src/transformations/SetEndOfLine.ts
@@ -19,6 +19,8 @@ export class SetEndOfLine extends PreSaveTransformation {
 		const eolKey = (editorconfigProperties.end_of_line || '').toUpperCase()
 		const eol = this.eolMap[eolKey as keyof typeof eolMap]
 
+		if (!eol) return noEdits()
+
 		/**
 		 * VSCode normalizes line endings on every file-save operation
 		 * according to whichever EOL sequence is dominant. If the file already
@@ -26,10 +28,14 @@ export class SetEndOfLine extends PreSaveTransformation {
 		 * so we defer to VSCode's built-in functionality by applying no edits.
 		 */
 		return doc.eol === eol
-			? { edits: [] }
+			? noEdits()
 			: {
 					edits: [TextEdit.setEndOfLine(eol)],
 					message: `setEndOfLine(${eolKey})`,
 			  }
+
+		function noEdits() {
+			return { edits: [] }
+		}
 	}
 }


### PR DESCRIPTION
Fix https://github.com/editorconfig/editorconfig-vscode/issues/299.

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

