### PR TITLE
change activation event to onStartupFinished instead of *

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./out/editorConfigMain.js",
   "types": "./out/editorConfigMain.d.ts",


### PR DESCRIPTION
`*` should only be used when absolutely necessary, and no other combination of events can be used.  I think `onStartupFinished` fits best here.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

