### PR TITLE
apply options on file when reloading window

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -4,6 +4,7 @@ import {
 	Selection,
 	TextDocument,
 	TextDocumentSaveReason,
+	TextEditor,
 	TextEditorOptions,
 	window,
 	workspace,
@@ -38,20 +39,11 @@ export default class DocumentWatcher {
 
 		const subscriptions: Disposable[] = []
 
+		this.handleTextEditorChange(window.activeTextEditor)
+
 		subscriptions.push(
 			window.onDidChangeActiveTextEditor(async editor => {
-				if (editor && editor.document) {
-					const newOptions = await resolveTextEditorOptions(
-						(this.doc = editor.document),
-						{
-							onEmptyConfig: this.onEmptyConfig,
-						},
-					)
-					applyTextEditorOptions(newOptions, {
-						onNoActiveTextEditor: this.onNoActiveTextEditor,
-						onSuccess: this.onSuccess,
-					})
-				}
+				this.handleTextEditorChange(editor)
 			}),
 		)
 
@@ -162,5 +154,20 @@ export default class DocumentWatcher {
 				return edits
 			}),
 		]
+	}
+
+	private async handleTextEditorChange(editor?: TextEditor) {
+		if (editor && editor.document) {
+			const newOptions = await resolveTextEditorOptions(
+				(this.doc = editor.document),
+				{
+					onEmptyConfig: this.onEmptyConfig,
+				},
+			)
+			applyTextEditorOptions(newOptions, {
+				onNoActiveTextEditor: this.onNoActiveTextEditor,
+				onSuccess: this.onSuccess,
+			})
+		}
 	}
 }


### PR DESCRIPTION
When reloading the window, options aren't applied until switching editors or another event to trigger.  This checks the active text editor and applies the options.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

fixes https://github.com/editorconfig/editorconfig-vscode/issues/283
