### PR TITLE
fix: keep selection on formatting

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -8,6 +8,7 @@ import {
 	TextEditorOptions,
 	window,
 	workspace,
+	WorkspaceEdit,
 } from 'vscode'
 import {
 	InsertFinalNewline,
@@ -81,12 +82,14 @@ export default class DocumentWatcher {
 					e.document,
 					e.reason,
 				)
-				e.waitUntil(transformations)
-				if (selections.length) {
-					const edits = await transformations
-					if (activeEditor && edits.length) {
-						activeEditor.selections = selections
-					}
+
+				const workspaceEdit = new WorkspaceEdit()
+				const textEdits = await transformations
+				workspaceEdit.set(e.document.uri, textEdits)
+				await workspace.applyEdit(workspaceEdit)
+
+				if (activeEditor && textEdits.length && selections.length) {
+					activeEditor.selections = selections
 				}
 			}),
 		)

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -76,7 +76,7 @@ export default class DocumentWatcher {
 				const activeEditor = window.activeTextEditor
 				const activeDoc = activeEditor?.document
 				if (activeDoc && activeDoc === e.document && activeEditor) {
-					selections = activeEditor.selections
+					selections = [...activeEditor.selections]
 				}
 				const transformations = this.calculatePreSaveTransformations(
 					e.document,

--- a/src/test/suite/index.test.ts
+++ b/src/test/suite/index.test.ts
@@ -334,11 +334,17 @@ function withSetting(
 	async function createDoc(contents = '') {
 		const uri = await utils.createFile(
 			contents,
-			getFixturePath([rule, value, Math.random().toString(36)]),
+			generateFixturePath().next().value,
 		)
 		const doc = await workspace.openTextDocument(uri)
 		await window.showTextDocument(doc)
 		await wait(50) // wait for EditorConfig to apply new settings
 		return doc
+	}
+	function* generateFixturePath(): Generator<string> {
+		let index = 0
+		while (true) {
+			yield getFixturePath([rule, value, `${test}-${index++}`])
+		}
 	}
 }

--- a/src/test/suite/index.test.ts
+++ b/src/test/suite/index.test.ts
@@ -291,6 +291,7 @@ suite('EditorConfig extension', function () {
 		}).saveText('foobar')
 		assert(window.activeTextEditor, 'no active editor')
 
+                // Before saving, the selection is on line 0. This should remain unchanged.
 		assert.strictEqual(
 			window.activeTextEditor.selection.start.line,
 			0,

--- a/src/test/suite/index.test.ts
+++ b/src/test/suite/index.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as os from 'os'
-import { Position, window, workspace, WorkspaceEdit } from 'vscode'
+import { Position, window, workspace, WorkspaceEdit, Uri } from 'vscode'
 import { getFixturePath, getOptionsForFixture, wait } from '../testUtils'
 
 import * as utils from 'vscode-test-utils'
@@ -335,10 +335,15 @@ function withSetting(
 		},
 	}
 	async function createDoc(contents = '', name = 'test') {
-		const uri = await utils.createFile(
-			contents,
-			getFixturePath([rule, value, name]),
-		)
+		const fixturePath = getFixturePath([rule, value, name])
+
+		try {
+			await workspace.fs.delete(Uri.file(fixturePath))
+		} catch {
+			// ignore
+		}
+
+		const uri = await utils.createFile(contents, fixturePath)
 		const doc = await workspace.openTextDocument(uri)
 		await window.showTextDocument(doc)
 		await wait(50) // wait for EditorConfig to apply new settings

--- a/src/test/suite/index.test.ts
+++ b/src/test/suite/index.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import * as os from 'os'
-import { Position, window, workspace, WorkspaceEdit, Selection } from 'vscode'
+import { Position, window, workspace, WorkspaceEdit } from 'vscode'
 import { getFixturePath, getOptionsForFixture, wait } from '../testUtils'
 
 import * as utils from 'vscode-test-utils'


### PR DESCRIPTION
- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run compile`).
- [x] Run `npm run lint` w/o errors.

fixes #330 and its duplicates 