### PR TITLE
feat: add option to disable context menu entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
           "type": "string",
           "default": "default",
           "description": "If generateAuto is false, this template path will be used for each newly-generated .editorconfig file."
+        },
+        "editorconfig.showMenuEntry": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the 'Generate .editorconfig' entry in the context menu of the Explorer view."
         }
       }
     },
@@ -61,13 +66,13 @@
       "commandPalette": [
         {
           "command": "EditorConfig.generate",
-          "when": "explorerResourceIsFolder"
+          "when": "explorerResourceIsFolder && config.editorconfig.showMenuEntry"
         }
       ],
       "explorer/context": [
         {
           "command": "EditorConfig.generate",
-          "when": "explorerResourceIsFolder",
+          "when": "explorerResourceIsFolder && config.editorconfig.showMenuEntry",
           "group": "EditorConfig@1"
         }
       ]


### PR DESCRIPTION
~and hide the entry when editorconfig already exists~

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run build`).
- [x] Run `npm run lint` w/o errors.

fixes #331