### PR TITLE
fix: restore selections only after applying changes 

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -41,7 +41,7 @@ export default class DocumentWatcher {
 
 		let editedDoc: TextDocument | undefined
 
-		let shouldRestoreSelection = false
+		let shouldRestoreSelections = false
 
 		let previousSelections: Selection[] = []
 
@@ -72,13 +72,13 @@ export default class DocumentWatcher {
 				const activeEditor = window.activeTextEditor
 				const activeDoc = activeEditor?.document
 				if (
-					shouldRestoreSelection &&
+					shouldRestoreSelections &&
 					activeEditor &&
 					doc === editedDoc &&
 					doc === activeDoc
 				) {
 					activeEditor.selections = [...previousSelections]
-					shouldRestoreSelection = false
+					shouldRestoreSelections = false
 				}
 
 				if (path.basename(doc.fileName) === '.editorconfig') {
@@ -99,7 +99,7 @@ export default class DocumentWatcher {
 					e.reason,
 				)
 				e.waitUntil(transformations)
-				shouldRestoreSelection = (await transformations).length > 0
+				shouldRestoreSelections = (await transformations).length > 0
 				editedDoc = activeDoc
 			}),
 		)


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run build`).
- [x] Run `npm run lint` w/o errors.

fixes #409 
fixes #408 
fixes #407

the issue was introduced in #397

TODO: test