### PR TITLE
revert: don't restore selections

### DIFF
--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -1,7 +1,6 @@
 import * as path from 'path'
 import {
 	Disposable,
-	Selection,
 	TextDocument,
 	TextDocumentSaveReason,
 	TextEditor,
@@ -39,8 +38,6 @@ export default class DocumentWatcher {
 
 		const subscriptions: Disposable[] = []
 
-		let previousSelections: Selection[] = []
-
 		this.handleTextEditorChange(window.activeTextEditor)
 
 		subscriptions.push(
@@ -65,11 +62,6 @@ export default class DocumentWatcher {
 
 		subscriptions.push(
 			workspace.onDidSaveTextDocument(doc => {
-				const activeEditor = window.activeTextEditor
-				if (activeEditor && previousSelections.length) {
-					activeEditor.selections = previousSelections
-				}
-
 				if (path.basename(doc.fileName) === '.editorconfig') {
 					this.log('.editorconfig file saved.')
 				}
@@ -78,11 +70,6 @@ export default class DocumentWatcher {
 
 		subscriptions.push(
 			workspace.onWillSaveTextDocument(async e => {
-				const activeEditor = window.activeTextEditor
-				const activeDoc = activeEditor?.document
-				if (activeDoc && activeDoc === e.document && activeEditor) {
-					previousSelections = [...activeEditor.selections]
-				}
 				const transformations = this.calculatePreSaveTransformations(
 					e.document,
 					e.reason,

--- a/src/test/suite/index.test.ts
+++ b/src/test/suite/index.test.ts
@@ -285,24 +285,24 @@ suite('EditorConfig extension', function () {
 		)
 	})
 
-	test('keep selection on format', async () => {
-		await withSetting('insert_final_newline', 'true', {
-			fileName: 'test-selection',
-		}).saveText('foobar')
-		assert(window.activeTextEditor, 'no active editor')
+	// test('keep selection on format', async () => {
+	// 	await withSetting('insert_final_newline', 'true', {
+	// 		fileName: 'test-selection',
+	// 	}).saveText('foobar')
+	// 	assert(window.activeTextEditor, 'no active editor')
 
-		// Before saving, the selection is on line 0. This should remain unchanged.
-		assert.strictEqual(
-			window.activeTextEditor.selection.start.line,
-			0,
-			'editor selection start line changed',
-		)
-		assert.strictEqual(
-			window.activeTextEditor.selection.end.line,
-			0,
-			'editor selection end line changed',
-		)
-	})
+	// 	// Before saving, the selection is on line 0. This should remain unchanged.
+	// 	assert.strictEqual(
+	// 		window.activeTextEditor.selection.start.line,
+	// 		0,
+	// 		'editor selection start line changed',
+	// 	)
+	// 	assert.strictEqual(
+	// 		window.activeTextEditor.selection.end.line,
+	// 		0,
+	// 		'editor selection end line changed',
+	// 	)
+	// })
 })
 
 function withSetting(


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run build`).
- [x] Run `npm run lint` w/o errors.

fixes #407
fixes #408
fixes #409
fixes #411

this is a temporary measure until the vscode update is released