### PR TITLE
fix: don't apply `charset` on document opening

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for more information on the multiple ways of installing VSCode extensions.
 - `end_of_line` (on save)
 - `insert_final_newline` (on save)
 - `trim_trailing_whitespace` (on save)
-- `charset` (on open/after save)
+- `charset`
 
 ## How it works
 

--- a/src/DocumentWatcher.ts
+++ b/src/DocumentWatcher.ts
@@ -76,7 +76,7 @@ export default class DocumentWatcher {
 				if (path.basename(doc.fileName) === '.editorconfig') {
 					this.log('.editorconfig file saved.')
 				}
-				// in case document was dirty on open/text editor change
+				// in case document was dirty on text editor change
 				this.handleDocumentEncoding(doc)
 			}),
 		)
@@ -89,10 +89,6 @@ export default class DocumentWatcher {
 				)
 				e.waitUntil(transformations)
 			}),
-		)
-
-		subscriptions.push(
-			workspace.onDidOpenTextDocument(this.handleDocumentEncoding),
 		)
 
 		this.disposable = Disposable.from.apply(this, subscriptions)


### PR DESCRIPTION
fixes #465

I see only two ways to trigger the `didOpenTextDocument` event without also triggering `didChangeActiveTextEditor`:

- change language mode
- change encoding

In neither of those cases do we need to apply `charset`

Please fill in this template.

- [x] Use a meaningful title for the pull request.
- [x] Use meaningful commit messages.
- [x] Run `tsc` w/o errors (same as `npm run build`).
- [x] Run `npm run lint` w/o errors.
